### PR TITLE
`dashu` and `malachite` support (`rug` alternatives) and other stuff.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,26 +12,26 @@ exclude = ["plot_vortess.py", "shell.nix"]
 
 [dependencies]
 ahash = "0.8"
+dashu = { version = "0.4", optional = true }
 document-features = "0.2"
 glam = "0.27"
 hdf5 = { version = "0.8", optional = true }
 malachite-base = { version = "0.4", optional = true }
 malachite-nz = { version = "0.4", optional = true }
+num_enum = { version = "0.7.2", default-features = false }
 rayon = { version = "1", optional = true }
 rstar = "0.12"
 rug = { version = "1.24", optional = true }
 
 [features]
-default = ["malachite", "rayon"]
+default = ["dashu", "rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
-## Use the `malachite` crate for arbitrary precision integer arithmethic.
-## This is slower than `rug` but builds considerably faster and allows
-## the crate itself to remain under the MIT/Apache licenses.
+## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
+dashu = ["dep:dashu"]
+## Use the `malachite` crate as the arbitrary precision integer arithmethic backen.
 malachite = ["malachite-nz", "malachite-base"]
-## Use the `rug` crate for arbitrary precision integer arithmethic. This is
-## faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
-## crate which makes this crate fall under the GPL license.
+## Use the `rug` crate as arbitrary precision integer arithmethic backend.
 rug = ["dep:rug"]
 ## Allow saving Voronoi grids to
 ## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,42 @@
 [package]
 name = "meshless_voronoi"
-description = "An implementation of the Meshless Voronoi algorithm in rust."
+description = "An implementation of the Meshless Voronoi algorithm."
 version = "0.5.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yuyttenhove/meshless_voro"
-keywords = ["voronoi","graphics","diagram"]
-categories = ["graphics","science", "mathematics"]
+documentation = "https://docs.rs/meshless_voronoi"
+keywords = ["voronoi", "graphics", "diagram"]
+categories = ["graphics", "science", "mathematics"]
 exclude = ["plot_vortess.py", "shell.nix"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-glam = { version="0.23" }
-rstar = "0.10"
-rayon = { version = "1.7", optional = true }
+ahash = "0.8"
+document-features = "0.2"
+glam = "0.27"
 hdf5 = { version = "0.8", optional = true }
-rug = "1.19.1"
+malachite-base = { version = "0.4", optional = true }
+malachite-nz = { version = "0.4", optional = true }
+rayon = { version = "1", optional = true }
+rstar = "0.12"
+rug = { version = "1.24", optional = true }
 
 [features]
+default = ["malachite", "rayon"]
+## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
+## Use the `malachite` crate for arbitrary precision integer arithmethic.
+## This is slower than `rug` but builds considerably faster and allows
+## the crate itself to remain under the MIT/Apache licenses.
+malachite = ["malachite-nz", "malachite-base"]
+## Use the `rug` crate for arbitrary precision integer arithmethic. This is
+## faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
+## crate which makes this crate fall under the GPL license.
+rug = ["dep:rug"]
+## Allow saving Voronoi grids to
+## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).
 hdf5 = ["dep:hdf5"]
 
 [dev-dependencies]
-rand = "0.8"
 float-cmp = "0.9"
+rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ rayon = ["dep:rayon"]
 dashu = ["dep:dashu"]
 ## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
 malachite = ["malachite-nz", "malachite-base"]
-## Use the `num-bigint` crate as the arbitrary precision integer arithmethic backend.
+## Use the `num_bigint` crate as the arbitrary precision integer arithmethic backend.
 num_bigint = ["dep:num-bigint"]
 ## Use the `rug` crate as arbitrary precision integer arithmethic backend. 
-## *Warning* this changes the license to the more restrictive LGPL-3.0+ license.
+## *Warning:* this changes the license to the more restrictive LGPL-3.0+ license.
 rug = ["dep:rug"]
 ## Allow saving Voronoi grids to
 ## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rayon = ["dep:rayon"]
 dashu = ["dep:dashu"]
 ## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
 malachite = ["malachite-nz", "malachite-base"]
+## Use the `num-bigint` crate as the arbitrary precision integer arithmethic backend.
 num_bigint = ["dep:num-bigint"]
 ## Use the `rug` crate as arbitrary precision integer arithmethic backend.
 rug = ["dep:rug"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rstar = "0.12"
 rug = { version = "1.24", optional = true }
 
 [features]
-default = ["dashu", "rayon"]
+default = ["num_bigint", "rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
 ## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
@@ -34,7 +34,8 @@ dashu = ["dep:dashu"]
 malachite = ["malachite-nz", "malachite-base"]
 ## Use the `num-bigint` crate as the arbitrary precision integer arithmethic backend.
 num_bigint = ["dep:num-bigint"]
-## Use the `rug` crate as arbitrary precision integer arithmethic backend.
+## Use the `rug` crate as arbitrary precision integer arithmethic backend. 
+## *Warning* this changes the license to the more restrictive LGPL-3.0+ license.
 rug = ["dep:rug"]
 ## Allow saving Voronoi grids to
 ## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ glam = "0.27"
 hdf5 = { version = "0.8", optional = true }
 malachite-base = { version = "0.4", optional = true }
 malachite-nz = { version = "0.4", optional = true }
+num-bigint = { version = "0.4", optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 rayon = { version = "1", optional = true }
 rstar = "0.12"
@@ -29,8 +30,9 @@ default = ["dashu", "rayon"]
 rayon = ["dep:rayon"]
 ## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
 dashu = ["dep:dashu"]
-## Use the `malachite` crate as the arbitrary precision integer arithmethic backen.
+## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
 malachite = ["malachite-nz", "malachite-base"]
+num_bigint = ["dep:num-bigint"]
 ## Use the `rug` crate as arbitrary precision integer arithmethic backend.
 rug = ["dep:rug"]
 ## Allow saving Voronoi grids to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rstar = "0.12"
 rug = { version = "1.24", optional = true,  default-features = false, features = ["integer"] }
 
 [features]
-default = ["dashu", "rayon"]
+default = ["ibig", "rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
 ## Allow saving Voronoi grids to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,24 +26,24 @@ rstar = "0.12"
 rug = { version = "1.24", optional = true,  default-features = false, features = ["integer"] }
 
 [features]
-default = ["ibig", "rayon"]
+default = ["dashu", "rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
-## Use the `ibig` crate as the arbitrary precision integer arithmethic backend.
-ibig = ["dep:ibig"]
-## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
-dashu = ["dep:dashu"]
-## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
-## *Warning:* this changes the license to the more restrictive LGPL-3.0-only license.
-malachite = ["malachite-nz", "malachite-base"]
-## Use the `num_bigint` crate as the arbitrary precision integer arithmethic backend.
-num_bigint = ["dep:num-bigint"]
-## Use the `rug` crate as arbitrary precision integer arithmethic backend. 
-## *Warning:* this changes the license to the more restrictive LGPL-3.0+ license.
-rug = ["dep:rug"]
 ## Allow saving Voronoi grids to
 ## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).
 hdf5 = ["dep:hdf5"]
+## Use the `dashu` crate as the arbitrary precision integer arithmetic backend.
+dashu = ["dep:dashu"]
+## Use the `ibig` crate as the arbitrary precision integer arithmetic backend.
+ibig = ["dep:ibig"]
+## Use the `malachite` crate as the arbitrary precision integer arithmetic backend.
+## *Warning:* this changes the license to the more restrictive LGPL-3.0-only license.
+malachite = ["malachite-nz", "malachite-base"]
+## Use the `num_bigint` crate as the arbitrary precision integer arithmetic backend.
+num_bigint = ["dep:num-bigint"]
+## Use the `rug` crate as arbitrary precision integer arithmetic backend.
+## *Warning:* this changes the license to the more restrictive LGPL-3.0+ license.
+rug = ["dep:rug"]
 
 [dev-dependencies]
 float-cmp = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,30 +12,23 @@ exclude = ["plot_vortess.py", "shell.nix"]
 
 [dependencies]
 ahash = "0.8"
-dashu = { version = "0.4", optional = true }
 document-features = "0.2"
 glam = "0.27"
 hdf5 = { version = "0.8", optional = true }
-malachite-base = { version = "0.4", optional = true }
-malachite-nz = { version = "0.4", optional = true }
-num-bigint = { version = "0.4", optional = true }
+num-bigint = { version = "0.4" }
 num_enum = { version = "0.7.2", default-features = false }
 rayon = { version = "1", optional = true }
 rstar = "0.12"
 rug = { version = "1.24", optional = true }
 
 [features]
-default = ["num_bigint", "rayon"]
+default = ["rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
-## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
-dashu = ["dep:dashu"]
-## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
-malachite = ["malachite-nz", "malachite-base"]
-## Use the `num_bigint` crate as the arbitrary precision integer arithmethic backend.
-num_bigint = ["dep:num-bigint"]
-## Use the `rug` crate as arbitrary precision integer arithmethic backend. 
-## *Warning:* this changes the license to the more restrictive LGPL-3.0+ license.
+## Use the `rug` crate as arbitrary precision integer arithmethic backend instead of 
+## the default `big_int`. This can increase performance significantly for highly degenerate 
+## seed configurations where lots of arbitrary precision arithmetic is needed. 
+## *Disclaimer:* this changes the license to the more restrictive LGPL-3.0+ license.
 rug = ["dep:rug"]
 ## Allow saving Voronoi grids to
 ## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,30 @@ exclude = ["plot_vortess.py", "shell.nix"]
 
 [dependencies]
 ahash = "0.8"
+dashu = { version = "0.4", optional = true }
 document-features = "0.2"
 glam = "0.27"
 hdf5 = { version = "0.8", optional = true }
-num-bigint = { version = "0.4" }
+malachite-base = { version = "0.4", optional = true }
+malachite-nz = { version = "0.4", optional = true }
+num-bigint = { version = "0.4", optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 rayon = { version = "1", optional = true }
 rstar = "0.12"
 rug = { version = "1.24", optional = true }
 
 [features]
-default = ["rayon"]
+default = ["num_bigint", "rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
-## Use the `rug` crate as arbitrary precision integer arithmethic backend instead of 
-## the default `big_int`. This can increase performance significantly for highly degenerate 
-## seed configurations where lots of arbitrary precision arithmetic is needed. 
-## *Disclaimer:* this changes the license to the more restrictive LGPL-3.0+ license.
+## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
+dashu = ["dep:dashu"]
+## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
+malachite = ["malachite-nz", "malachite-base"]
+## Use the `num_bigint` crate as the arbitrary precision integer arithmethic backend.
+num_bigint = ["dep:num-bigint"]
+## Use the `rug` crate as arbitrary precision integer arithmethic backend. 
+## *Warning:* this changes the license to the more restrictive LGPL-3.0+ license.
 rug = ["dep:rug"]
 ## Allow saving Voronoi grids to
 ## [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "meshless_voronoi"
 description = "An implementation of the Meshless Voronoi algorithm."
 version = "0.5.9"
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license = "MIT OR Apache-2.0 OR LGPL-3.0-only OR LGPL-3.0+"
 repository = "https://github.com/yuyttenhove/meshless_voro"
 documentation = "https://docs.rs/meshless_voronoi"
 keywords = ["voronoi", "graphics", "diagram"]
@@ -16,21 +16,25 @@ dashu = { version = "0.4", optional = true }
 document-features = "0.2"
 glam = "0.27"
 hdf5 = { version = "0.8", optional = true }
+ibig = {  version = "0.3", optional = true, default-features = false }
 malachite-base = { version = "0.4", optional = true }
 malachite-nz = { version = "0.4", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 rayon = { version = "1", optional = true }
 rstar = "0.12"
-rug = { version = "1.24", optional = true }
+rug = { version = "1.24", optional = true,  default-features = false, features = ["integer"] }
 
 [features]
-default = ["num_bigint", "rayon"]
+default = ["ibig", "rayon"]
 ## Enable parallel construction of the Voronoi grid.
 rayon = ["dep:rayon"]
+## Use the `ibig` crate as the arbitrary precision integer arithmethic backend.
+ibig = ["dep:ibig"]
 ## Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
 dashu = ["dep:dashu"]
 ## Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
+## *Warning:* this changes the license to the more restrictive LGPL-3.0-only license.
 malachite = ["malachite-nz", "malachite-base"]
 ## Use the `num_bigint` crate as the arbitrary precision integer arithmethic backend.
 num_bigint = ["dep:num-bigint"]

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ It should be noted that this backend requires a C compiler to build and hence ha
 - `rayon` (enabled by default) – Enable parallel construction of the Voronoi
   grid.
 
-- `dashu` – Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
-
-- `malachite` – Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
-
 - `rug` – Use the `rug` crate as the arbitrary precision integer arithmethic backend.
 
 - `hdf5` – Allow saving Voronoi grids to HDF5 format.

--- a/README.md
+++ b/README.md
@@ -43,19 +43,17 @@ info:
 
 ## Integer Arithmetic Backend
 
-You can select from three backends for arbitrary precision integer
-arithmetic.
+The default backend for arbitrary precision integer arithemtic is 
+[`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0).
+For most use cases there is no significant performance difference between the different 
+backends and `num_bigint` is the fastest to build.
 
-- [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0) runs the test
-  suit at the same speed as `rug`. This is the default backend.
+However, for highly degenerate seed configurations, it is recommended to use the alternative 
+[`rug`](https://crates.io/crates/rug) (LGPL-3.0+) backend, which can increase performance 
+up to 2x in these cases.
+It should be noted that this backend requires a C compiler to build and hence has the slowest build time.
 
-- [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only) runs the
-  test suite about 6% slower than `rug` but builds considerably faster.
-
-- [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) runs the test suite
-  faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
-  crate which requires a C compiler to build and has the slowest build time
-  thus.
+*Using the `rug` backend also changes the license of the crate to LGPL-3.0+.*
 
 ## Cargo Features
 

--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ It should be noted that this backend requires a C compiler to build and hence ha
 
 ## License
 
-Apache-2.0 OR MIT at your option when using the `dashu` backend OR LGPL-3.0-only
-(`malachite` backend) OR LGPL-3.0+ (`rug` backend).
+Apache-2.0 OR MIT at your option when using the default (`num_bigint`) backend OR LGPL-3.0+ (`rug` backend).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It should be noted that this backend requires a C compiler to build and hence ha
   This can increase performance significantly for highly degenerate seed configurations where lots of arbitrary 
   precision arithmetic is needed. 
   
-  *Disclaimer:* this changes the license to the more restrictive LGPL-3.0+ license..
+  *Disclaimer:* this changes the license to the more restrictive LGPL-3.0+ license.
 
 - `hdf5` – Allow saving Voronoi grids to HDF5 format.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ info:
 
 ## Integer Arithmetic Backend
 
-You can select from three backends for arbitrary precision integer arithmetic.
+You can select from five backends for arbitrary precision integer arithmetic.
 These all provide identical functionality and vary only in performance and licensing.
 
 For most practical applications, the choice of backend does not significantly alter

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ It should be noted that this backend requires a C compiler to build and hence ha
 - `rayon` (enabled by default) – Enable parallel construction of the Voronoi
   grid.
 
-- `rug` – Use the `rug` crate as the arbitrary precision integer arithmethic backend.
+- `rug` – Use the `rug` crate as the arbitrary precision integer arithmethic backend instead of the default `big_int`. 
+  This can increase performance significantly for highly degenerate seed configurations where lots of arbitrary 
+  precision arithmetic is needed. 
+  
+  *Disclaimer:* this changes the license to the more restrictive LGPL-3.0+ license..
 
 - `hdf5` – Allow saving Voronoi grids to HDF5 format.
 

--- a/README.md
+++ b/README.md
@@ -71,4 +71,8 @@ It should be noted that this backend requires a C compiler to build and hence ha
 
 ## License
 
-Apache-2.0 OR MIT at your option when using the default (`num_bigint`) backend OR LGPL-3.0+ (`rug` backend).
+Licensed under:
+ - [Apache-2.0](www.apache.org/licenses/LICENSE-2.0) OR [MIT](https://opensource.org/license/MIT) at your option when 
+   using the `ibig`, `dashu` or `num_bigint` arbitrary precision arithmetic backends.
+ - [LGPL-3.0-only](https://www.gnu.org/licenses/lgpl-3.0.html) when using the `malachite` backend
+ - [LGPL-3.0+](https://www.gnu.org/licenses/lgpl-3.0.html) when using the `rug` backend.

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ performance. However, for highly degenerate seed configurations - i.e. with many
 than 4 (almost) co-spherical seed points - many arbitrary precision arithmetic tests must be
 performed leading to some performance differences in such cases.
 
-- [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0): This is the default backend.
-  Can be up to 40% slower than the `rug` backend for highly degenerate seed configurations.
+- [`ibig`](https://crates.io/crates/ibig) (MIT/Apache 2.0): This is the default backend.
+  It generally has good performance, but can be up to 40% slower than the `rug` backend for
+  highly degenerate seed configurations.
 
-- [`ibig`](https://crates.io/crates/ibig) (MIT/Apache 2.0): Similar performance to the `dashu`
+- [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0): Similar performance to the `ibig`
   backend.
 
 - [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0): Worst performance for
@@ -75,9 +76,9 @@ performed leading to some performance differences in such cases.
 
 - `hdf5` – Allow saving Voronoi grids to [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).
 
-- `dashu` (enabled by default) — Use the `dashu` crate as the arbitrary precision integer arithmetic backend.
+- `dashu` — Use the `dashu` crate as the arbitrary precision integer arithmetic backend.
 
-- `ibig` — Use the `ibig` crate as the arbitrary precision integer arithmetic backend.
+- `ibig` (enabled by default) — Use the `ibig` crate as the arbitrary precision integer arithmetic backend.
 
 - `malachite` — Use the `malachite` crate as the arbitrary precision integer arithmetic backend. 
    

--- a/README.md
+++ b/README.md
@@ -43,17 +43,29 @@ info:
 
 ## Integer Arithmetic Backend
 
-The default backend for arbitrary precision integer arithemtic is 
-[`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0).
-For most use cases there is no significant performance difference between the different 
-backends and `num_bigint` is the fastest to build.
+You can select from three backends for arbitrary precision integer arithmetic.
+These all provide identical functionality and vary only in performance and licensing.
 
-However, for highly degenerate seed configurations, it is recommended to use the alternative 
-[`rug`](https://crates.io/crates/rug) (LGPL-3.0+) backend, which can increase performance 
-up to 2x in these cases.
-It should be noted that this backend requires a C compiler to build and hence has the slowest build time.
+For most practical applications, the choice of backend does not significantly alter
+performance. However, for highly degenerate seed configurations - i.e. with many groups of more
+than 4 (almost) co-spherical seed points - many arbitrary precision arithmetic tests must be
+performed leading to some performance differences in such cases.
 
-*Using the `rug` backend also changes the license of the crate to LGPL-3.0+.*
+- [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0): This is the default backend.
+  Can be up to 40% slower than the `rug` backend for highly degenerate seed configurations.
+
+- [`ibig`](https://crates.io/crates/ibig) (MIT/Apache 2.0): Similar performance to the `dashu`
+  backend.
+
+- [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0): Worst performance for
+  degenerate seed configurations (measured up to 109% slower than `rug`)
+
+- [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only): Slightly faster than the
+  `dashu` backend (up to 30% slower than `rug`).
+
+- [`rug`](https://crates.io/crates/rug) (LGPL-3.0+): The fastest backend, but depends on GNU GMP
+  via the `gmp-mpfr-sys` crate which requires a C compiler to build and hence has the slowest
+  build time.
 
 ## Cargo Features
 
@@ -61,13 +73,23 @@ It should be noted that this backend requires a C compiler to build and hence ha
 - `rayon` (enabled by default) – Enable parallel construction of the Voronoi
   grid.
 
-- `rug` – Use the `rug` crate as the arbitrary precision integer arithmethic backend instead of the default `big_int`. 
+- `hdf5` – Allow saving Voronoi grids to [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).
+
+- `dashu` (enabled by default) — Use the `dashu` crate as the arbitrary precision integer arithmetic backend.
+
+- `ibig` — Use the `ibig` crate as the arbitrary precision integer arithmetic backend.
+
+- `malachite` — Use the `malachite` crate as the arbitrary precision integer arithmetic backend. 
+   
+  *Disclaimer*: this changes the license to the more restrictive LGPL-3.0-only license.
+
+- `num_bigint` — Use the `num_bigint` crate as the arbitrary precision integer arithmetic backend.
+
+- `rug` – Use the `rug` crate as the arbitrary precision integer arithmetic backend. 
   This can increase performance significantly for highly degenerate seed configurations where lots of arbitrary 
   precision arithmetic is needed. 
   
   *Disclaimer:* this changes the license to the more restrictive LGPL-3.0+ license.
-
-- `hdf5` – Allow saving Voronoi grids to HDF5 format.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # `meshless_voronoi`
-
 <!-- cargo-rdme start -->
 
 **An implementation of the
@@ -42,18 +41,37 @@ info:
 - Evaluation of *custom integrals* for cells (e.g. weighted centroid) and
   faces (e.g. solid angles).
 
+## Integer Arithmetic Backend
+
+You can select from three backends for arbitrary precision integer
+arithmetic.
+
+- [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0) runs the test
+  suit at the same speed as `rug`. This is the default backend.
+
+- [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only) runs the
+  test suite about 6% slower than `rug` but builds considerably faster.
+
+- [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) runs the test suite
+  faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
+  crate which requires a C compiler to build and has the slowest build time
+  thus.
+
 ## Cargo Features
 
 <!-- cargo-rdme end -->
-- `rayon` (enabled by default) — Enable parallel construction of the Voronoi
+- `rayon` (enabled by default) – Enable parallel construction of the Voronoi
   grid.
 
-- `malachite` (enabled by default) — Use the `malachite` crate for arbitrary
-  precision integer arithmethic. This is slower than rug but builds considerably
-  faster and allows the crate itself to remain under the MIT/Apache licenses.
+- `dashu` – Use the `dashu` crate as the arbitrary precision integer arithmethic backend.
 
-- `rug` — Use the rug crate for arbitrary precision intger arithmethic. This is
-  faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys` crate
-  which makes this crate fall under the GPL license.
+- `malachite` – Use the `malachite` crate as the arbitrary precision integer arithmethic backend.
 
-- `hdf5` — Allow saving Voronoi grids to HDF5 format.
+- `rug` – Use the `rug` crate as the arbitrary precision integer arithmethic backend.
+
+- `hdf5` – Allow saving Voronoi grids to HDF5 format.
+
+## License
+
+Apache-2.0 OR MIT at your option when using the `dashu` backend OR LGPL-3.0-only
+(`malachite` backend) OR LGPL-3.0+ (`rug` backend).

--- a/README.md
+++ b/README.md
@@ -1,23 +1,59 @@
- # The meshless_voronoi Crate
+# `meshless_voronoi`
 
- **An implementation of the [Meshless Voronoi algorithm](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf) in rust.**
+<!-- cargo-rdme start -->
 
- The algorithm is primarily aimed at generating 3D Voronoi diagrams, but can also be used to compute 1D and 2D Voronoi diagrams.
- Like Voro++, this algorithm is _meshless_ implying that no global geometry is constructed. Instead a cell based approach is used and we only compute integrals (cell/face volumes and centroids) and connectivity information (it is possible to determine a cell's neighbours).
+**An implementation of the
+[Meshless Voronoi algorithm](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf)
+in Rust.**
 
- The algorithm can generate Voronoi tesselations with a rectangular boundary or periodic boundary conditions and also supports computing a subset of the Voronoi tesselation.
+The algorithm is primarily aimed at generating 3D
+[Voronoi diagrams](https://en.wikipedia.org/wiki/Voronoi_diagram), but can
+also be used to compute 1D and 2D Voronoi diagrams.
 
- If necessary, arbitrary precision arithmetic is used to treat degeneracies and to ensure globaly consistent local geometry, see the appendix of [this reference](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf) for more info:
- > <cite>Nicolas Ray, Dmitry Sokolov, Sylvain Lefebvre, Bruno Lévy. Meshless Voronoi on the GPU. ACM
- > Transactions on Graphics, 2018, 37 (6), pp.1-12.  10.1145/3272127.3275092 .  hal-01927559<cite>
+Like [`Voro++`](https://math.lbl.gov/voro++/), this algorithm is *meshless*
+implying that no global geometry is constructed. Instead a cell-based
+approach is used and we only compute integrals (cell/face volumes and
+centroids) and connectivity information (it is possible to determine a
+cell's neighbours).
 
- **Features:**
- - Construction of 1D, 2D and 3D Voronoi grids.
- - Partial construction of grids.
- - Parallel construction of the voronoi grid (requires `rayon` feature)
- - Save Voronoi grids to `.hdf5` format (requires `hdf5` feature)
- - Evaluation of custom _integrals_ for cells (e.g. weighted centroid) and faces (e.g. solid angles).
+The algorithm can generate Voronoi tessellations with a rectangular boundary
+or periodic boundary conditions and also supports computing a subset of the
+Voronoi tessellation.
 
- **Documentation:**
+If necessary, arbitrary precision arithmetic is used to treat degeneracies
+and to ensure globally consistent local geometry. See the appendix of [this
+reference](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf) for more
+info:
 
-https://docs.rs/meshless_voronoi/latest/meshless_voronoi/
+> <cite>Nicolas Ray, Dmitry Sokolov, Sylvain Lefebvre, Bruno Lévy. Meshless
+> Voronoi on the GPU. ACM Transactions on Graphics, 2018, 37 (6), pp.1-12.
+> 10.1145/3272127.3275092. hal-01927559</cite>
+
+## Features
+
+- Construction of 1D, 2D and 3D Voronoi grids.
+
+- Partial construction of grids.
+
+- Parallel construction of the Voronoi grid.
+
+- Saving Voronoi grids to [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).
+
+- Evaluation of *custom integrals* for cells (e.g. weighted centroid) and
+  faces (e.g. solid angles).
+
+## Cargo Features
+
+<!-- cargo-rdme end -->
+- `rayon` (enabled by default) — Enable parallel construction of the Voronoi
+  grid.
+
+- `malachite` (enabled by default) — Use the `malachite` crate for arbitrary
+  precision integer arithmethic. This is slower than rug but builds considerably
+  faster and allows the crate itself to remain under the MIT/Apache licenses.
+
+- `rug` — Use the rug crate for arbitrary precision intger arithmethic. This is
+  faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys` crate
+  which makes this crate fall under the GPL license.
+
+- `hdf5` — Allow saving Voronoi grids to HDF5 format.

--- a/plot_vortess_2d.py
+++ b/plot_vortess_2d.py
@@ -1,9 +1,9 @@
-
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 from pathlib import Path
 import h5py
+
 
 def read_faces(fname: Path) -> np.ndarray:
     data = h5py.File(fname, "r")
@@ -11,21 +11,28 @@ def read_faces(fname: Path) -> np.ndarray:
     end = data["Faces/End"][:][:, :2]
     return np.stack([start, end], axis=1)
 
+
 def read_generators(fname: Path) -> np.ndarray:
     data = h5py.File(fname, "r")
     return data["Cells/Generator"][:]
+
 
 def read_centroids(fname: Path) -> np.ndarray:
     data = h5py.File(fname, "r")
     return data["Cells/Centroid"][:]
 
-def plot(faces: np.ndarray, generators = None, centroids = None):
+
+def plot(faces: np.ndarray, generators=None, centroids=None):
     lines = LineCollection(faces, color="r", lw=1)
     fig, ax = plt.subplots(figsize=(6, 6))
     ax.add_collection(lines)
     ax.set_aspect("equal")
-    ax.set_xlim(min([f[:, 0].min() for f in faces]), max([f[:, 0].max() for f in faces]))
-    ax.set_ylim(min([f[:, 1].min() for f in faces]), max([f[:, 1].max() for f in faces]))
+    ax.set_xlim(
+        min([f[:, 0].min() for f in faces]), max([f[:, 0].max() for f in faces])
+    )
+    ax.set_ylim(
+        min([f[:, 1].min() for f in faces]), max([f[:, 1].max() for f in faces])
+    )
     if generators is not None:
         ax.scatter(generators[:, 0], generators[:, 1], c="green", s=0.5)
     if centroids is not None:
@@ -34,12 +41,14 @@ def plot(faces: np.ndarray, generators = None, centroids = None):
     fig.tight_layout()
     fig.savefig("test.png", dpi=300)
 
+
 def main(fname):
     plot(
-        faces = read_faces(fname),
-        generators = read_generators(fname),
-        centroids = read_centroids(fname),
+        faces=read_faces(fname),
+        generators=read_generators(fname),
+        centroids=read_centroids(fname),
     )
+
 
 if __name__ == "__main__":
     main("test_2_d.hdf5")

--- a/plot_vortess_2d.py
+++ b/plot_vortess_2d.py
@@ -1,16 +1,15 @@
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 from pathlib import Path
 import h5py
 
-
 def read_faces(fname: Path) -> np.ndarray:
     data = h5py.File(fname, "r")
     start = data["Faces/Start"][:][:, :2]
     end = data["Faces/End"][:][:, :2]
     return np.stack([start, end], axis=1)
-
 
 def read_generators(fname: Path) -> np.ndarray:
     data = h5py.File(fname, "r")
@@ -19,7 +18,6 @@ def read_generators(fname: Path) -> np.ndarray:
 def read_centroids(fname: Path) -> np.ndarray:
     data = h5py.File(fname, "r")
     return data["Cells/Centroid"][:]
-
 
 def plot(faces: np.ndarray, generators = None, centroids = None):
     lines = LineCollection(faces, color="r", lw=1)
@@ -36,14 +34,12 @@ def plot(faces: np.ndarray, generators = None, centroids = None):
     fig.tight_layout()
     fig.savefig("test.png", dpi=300)
 
-
 def main(fname):
     plot(
         faces = read_faces(fname),
         generators = read_generators(fname),
         centroids = read_centroids(fname),
     )
-
 
 if __name__ == "__main__":
     main("test_2_d.hdf5")

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+fn_call_width = 80
+array_width = 80
+chain_width = 80

--- a/src/bounding_sphere.rs
+++ b/src/bounding_sphere.rs
@@ -1,8 +1,6 @@
-use ahash::HashSet;
-
-use glam::DVec3;
-
 use crate::geometry::Sphere;
+use ahash::{HashSet, HashSetExt};
+use glam::DVec3;
 
 pub(crate) trait BoundingSphereSolver {
     fn bounding_sphere(points: &[DVec3]) -> Sphere;
@@ -159,7 +157,7 @@ impl BoundingSphereSolver for Epos6 {
 mod test {
     use glam::DVec3;
 
-    use super::{BoundingSphereSolver, Welzl, EPOS6};
+    use super::{BoundingSphereSolver, Epos6, Welzl};
 
     #[test]
     fn test_bound() {
@@ -221,7 +219,7 @@ mod test {
             assert!(sphere.contains(*point));
         }
 
-        let sphere_approx = EPOS6::bounding_sphere(&points);
+        let sphere_approx = Epos6::bounding_sphere(&points);
         for point in &points {
             assert!(sphere_approx.contains(*point));
         }
@@ -287,7 +285,7 @@ mod test {
             assert!(sphere.contains(*point));
         }
 
-        let sphere_approx = EPOS6::bounding_sphere(&points);
+        let sphere_approx = Epos6::bounding_sphere(&points);
         for point in &points {
             assert!(sphere_approx.contains(*point));
         }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -4,6 +4,8 @@
 #[cfg(feature = "dashu")]
 use dashu::Integer;
 use glam::{DMat3, DMat4, DVec3, DVec4};
+#[cfg(feature = "ibig")]
+use ibig::IBig as Integer;
 #[cfg(feature = "malachite")]
 use malachite_base::num::arithmetic::traits::Sign;
 #[cfg(feature = "malachite")]
@@ -289,7 +291,7 @@ pub(crate) fn in_sphere_test_exact(a: &[i64], b: &[i64], c: &[i64], d: &[i64], v
     big_int_det3x3!(b[0], b[1], b[2], c[0], c[1], c[2], d[0], d[1], d[2], tmp1, det);
     determinant -= &v[3] * &det;
 
-    #[cfg(any(feature = "dashu", feature = "rug"))]
+    #[cfg(any(feature = "dashu", feature = "ibig", feature = "rug"))]
     let result = determinant.signum().to_f64();
     #[cfg(feature = "dashu")]
     let result = result.value();

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -87,6 +87,7 @@ pub fn signed_area_tri(v0: DVec3, v1: DVec3, v2: DVec3, t: DVec3) -> f64 {
     n.length() * sign
 }
 
+/// A simple sphere struct.
 #[derive(Clone)]
 pub struct Sphere {
     pub center: DVec3,
@@ -94,6 +95,7 @@ pub struct Sphere {
 }
 
 impl Sphere {
+    /// Zero sized sphere at the origin.
     pub const EMPTY: Sphere = Sphere {
         center: DVec3::ZERO,
         radius: 0.,
@@ -103,6 +105,8 @@ impl Sphere {
         Self { center, radius }
     }
 
+    /// Create the smallest sphere through 2, 3 or 4 boundary points. 
+    /// When 0 or 1 points are given, an empty sphere is returned.
     pub fn from_boundary_points(points: &[DVec3]) -> Self {
         match points.len() {
             0 | 1 => Self::EMPTY,
@@ -117,13 +121,13 @@ impl Sphere {
     }
 
     /// Create a sphere through two given points with center the midpoint
-    /// between the two points
+    /// between the two points.
     pub fn from_two_points(a: DVec3, b: DVec3) -> Self {
         Self::new(0.5 * (a + b), 0.5 * a.distance(b))
     }
 
     /// Circumscribes sphere through three given points with center on the plane
-    /// spanned by the points
+    /// spanned by the points. I.e. the smallest sphere trough the three points.
     ///
     /// See <https://www.wikiwand.com/en/Circumscribed_circle#Higher_dimensions>.
     pub fn from_three_points(a: DVec3, b: DVec3, c: DVec3) -> Sphere {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,11 +1,19 @@
 //! A few general-purpose geometry functions and structs,
 //! which might also be useful for users of this library.
 
+#[cfg(feature = "dashu")]
+use dashu::Integer;
 use glam::{DMat3, DMat4, DVec3, DVec4};
-#[cfg(not(feature = "rug"))]
+#[cfg(feature = "malachite")]
+use malachite_base::num::arithmetic::traits::Sign;
+#[cfg(feature = "malachite")]
+use malachite_nz::integer::Integer;
+#[cfg(feature = "num_bigint")]
 use num_bigint::{BigInt as Integer, Sign};
 #[cfg(feature = "rug")]
 use rug::Integer;
+#[cfg(feature = "malachite")]
+use std::cmp::Ordering;
 
 /// A simple plane struct.
 #[derive(Clone, Debug)]
@@ -281,9 +289,17 @@ pub(crate) fn in_sphere_test_exact(a: &[i64], b: &[i64], c: &[i64], d: &[i64], v
     big_int_det3x3!(b[0], b[1], b[2], c[0], c[1], c[2], d[0], d[1], d[2], tmp1, det);
     determinant -= &v[3] * &det;
 
-    #[cfg(feature = "rug")]
+    #[cfg(any(feature = "dashu", feature = "rug"))]
     let result = determinant.signum().to_f64();
-    #[cfg(not(feature = "rug"))]
+    #[cfg(feature = "dashu")]
+    let result = result.value();
+    #[cfg(feature = "malachite")]
+    let result = match determinant.sign() {
+        Ordering::Less => -1.0,
+        Ordering::Equal => 0.0,
+        Ordering::Greater => 1.0,
+    };
+    #[cfg(feature = "num_bigint")]
     let result = match determinant.sign() {
         Sign::Minus => -1.0,
         Sign::NoSign => 0.0,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,15 +1,15 @@
 //! A few general-purpose geometry functions and structs,
 //! which might also be useful for users of this library.
 
+#[cfg(feature = "dashu")]
+use dashu::Integer;
 use glam::{DMat3, DMat4, DVec3, DVec4};
-#[cfg(not(feature = "rug"))]
+#[cfg(feature = "malachite")]
 use malachite_base::num::arithmetic::traits::Sign;
-#[cfg(not(feature = "rug"))]
+#[cfg(feature = "malachite")]
 use malachite_nz::integer::Integer;
 #[cfg(feature = "rug")]
 use rug::Integer;
-#[cfg(not(feature = "rug"))]
-use std::cmp::Ordering;
 
 /// A simple plane struct.
 #[derive(Clone, Debug)]
@@ -287,9 +287,11 @@ pub(crate) fn in_sphere_test_exact(a: &[i64], b: &[i64], c: &[i64], d: &[i64], v
     big_int_det3x3!(b[0], b[1], b[2], c[0], c[1], c[2], d[0], d[1], d[2], tmp1, det);
     determinant -= &v[3] * &det;
 
-    #[cfg(feature = "rug")]
+    #[cfg(any(feature = "dashu", feature = "rug"))]
     let result = determinant.signum().to_f64();
-    #[cfg(not(feature = "rug"))]
+    #[cfg(feature = "dashu")]
+    let result = result.value();
+    #[cfg(feature = "malachite")]
     let result = match determinant.sign() {
         Ordering::Less => -1.0,
         Ordering::Equal => 0.0,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -105,7 +105,7 @@ impl Sphere {
         Self { center, radius }
     }
 
-    /// Create the smallest sphere through 2, 3 or 4 boundary points. 
+    /// Create the smallest sphere through 2, 3 or 4 boundary points.
     /// When 0 or 1 points are given, an empty sphere is returned.
     pub fn from_boundary_points(points: &[DVec3]) -> Self {
         match points.len() {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -8,8 +8,12 @@ use glam::{DMat3, DMat4, DVec3, DVec4};
 use malachite_base::num::arithmetic::traits::Sign;
 #[cfg(feature = "malachite")]
 use malachite_nz::integer::Integer;
+#[cfg(feature = "malachite")]
+use std::cmp::Ordering;
 #[cfg(feature = "rug")]
 use rug::Integer;
+#[cfg(feature = "num_bigint")]
+use num_bigint::{BigInt as Integer, Sign};
 
 /// A simple plane struct.
 #[derive(Clone, Debug)]
@@ -227,8 +231,8 @@ macro_rules! big_int {
     ($a:expr, $b:expr) => {{
         let mut big_int_diff = [
             Integer::from($a[0] - $b[0]),
-            Integer::from($a[0] - $b[1]),
-            Integer::from($a[0] - $b[2]),
+            Integer::from($a[1] - $b[1]),
+            Integer::from($a[2] - $b[2]),
             Integer::default(),
         ];
         let mut norm2 = Integer::default();
@@ -296,6 +300,12 @@ pub(crate) fn in_sphere_test_exact(a: &[i64], b: &[i64], c: &[i64], d: &[i64], v
         Ordering::Less => -1.0,
         Ordering::Equal => 0.0,
         Ordering::Greater => 1.0,
+    };
+    #[cfg(feature = "num_bigint")]
+    let result = match determinant.sign() {
+        Sign::Minus => -1.0,
+        Sign::NoSign => 0.0,
+        Sign::Plus => 1.0,
     };
 
     result

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,19 +1,11 @@
 //! A few general-purpose geometry functions and structs,
 //! which might also be useful for users of this library.
 
-#[cfg(feature = "dashu")]
-use dashu::Integer;
 use glam::{DMat3, DMat4, DVec3, DVec4};
-#[cfg(feature = "malachite")]
-use malachite_base::num::arithmetic::traits::Sign;
-#[cfg(feature = "malachite")]
-use malachite_nz::integer::Integer;
-#[cfg(feature = "num_bigint")]
+#[cfg(not(feature = "rug"))]
 use num_bigint::{BigInt as Integer, Sign};
 #[cfg(feature = "rug")]
 use rug::Integer;
-#[cfg(feature = "malachite")]
-use std::cmp::Ordering;
 
 /// A simple plane struct.
 #[derive(Clone, Debug)]
@@ -285,17 +277,9 @@ pub(crate) fn in_sphere_test_exact(a: &[i64], b: &[i64], c: &[i64], d: &[i64], v
     big_int_det3x3!(b[0], b[1], b[2], c[0], c[1], c[2], d[0], d[1], d[2], tmp1, det);
     determinant -= &v[3] * &det;
 
-    #[cfg(any(feature = "dashu", feature = "rug"))]
+    #[cfg(feature = "rug")]
     let result = determinant.signum().to_f64();
-    #[cfg(feature = "dashu")]
-    let result = result.value();
-    #[cfg(feature = "malachite")]
-    let result = match determinant.sign() {
-        Ordering::Less => -1.0,
-        Ordering::Equal => 0.0,
-        Ordering::Greater => 1.0,
-    };
-    #[cfg(feature = "num_bigint")]
+    #[cfg(not(feature = "rug"))]
     let result = match determinant.sign() {
         Sign::Minus => -1.0,
         Sign::NoSign => 0.0,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -8,12 +8,12 @@ use glam::{DMat3, DMat4, DVec3, DVec4};
 use malachite_base::num::arithmetic::traits::Sign;
 #[cfg(feature = "malachite")]
 use malachite_nz::integer::Integer;
-#[cfg(feature = "malachite")]
-use std::cmp::Ordering;
-#[cfg(feature = "rug")]
-use rug::Integer;
 #[cfg(feature = "num_bigint")]
 use num_bigint::{BigInt as Integer, Sign};
+#[cfg(feature = "rug")]
+use rug::Integer;
+#[cfg(feature = "malachite")]
+use std::cmp::Ordering;
 
 /// A simple plane struct.
 #[derive(Clone, Debug)]
@@ -25,10 +25,7 @@ pub struct Plane {
 impl Plane {
     /// Create a plane from a normal vector and a point on the plane.
     pub fn new(n: DVec3, p: DVec3) -> Self {
-        Self {
-            n,
-            p,
-        }
+        Self { n, p }
     }
 
     /// Project a point onto plane.
@@ -111,10 +108,7 @@ impl Sphere {
     };
 
     pub fn new(center: DVec3, radius: f64) -> Self {
-        Self {
-            center,
-            radius,
-        }
+        Self { center, radius }
     }
 
     pub fn from_boundary_points(points: &[DVec3]) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,11 @@
 //! than 4 (almost) co-spherical seed points - many arbitrary precision arithmetic tests must be
 //! performed leading to some performance differences in such cases.
 //!
-//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0): This is the default backend.
-//!   Can be up to 40% slower than the `rug` backend for highly degenerate seed configurations.
+//! - [`ibig`](https://crates.io/crates/ibig) (MIT/Apache 2.0): This is the default backend.
+//!   It generally has good performance, but can be up to 40% slower than the `rug` backend for
+//!   highly degenerate seed configurations.
 //!
-//! - [`ibig`](https://crates.io/crates/ibig) (MIT/Apache 2.0): Similar performance to the `dashu`
+//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0): Similar performance to the `ibig`
 //!   backend.
 //!
 //! - [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0): Worst performance for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,33 +40,54 @@
 //!
 //! # Integer Arithmetic Backend
 //!
-//! You can select from three backends for arbitrary precision integer
-//! arithmetic.
+//! You can select from three backends for arbitrary precision integer arithmetic.
+//! These all provide identical functionality and vary only in performance and licensing.
 //!
-//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0) runs the test
-//!   suit at the same speed as `rug`. This is the default backend.
+//! For most practical applications, the choice of backend does not significantly alter
+//! performance. However, for highly degenerate seed configurations - i.e. with many groups of more
+//! than 4 (almost) co-spherical seed points - many arbitrary precision arithmetic tests must be
+//! performed leading to some performance differences in such cases.
 //!
-//! - [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only) runs the
-//!   test suite about 6% slower than `rug` but builds considerably faster.
+//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0): This is the default backend.
+//!   Can be up to 40% slower than the `rug` backend for highly degenerate seed configurations.
 //!
-//! - [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) runs the test suite
-//!   faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
-//!   crate which requires a C compiler to build and has the slowest build time
-//!   thus.
+//! - [`ibig`](https://crates.io/crates/ibig) (MIT/Apache 2.0): Similar performance to the `dashu`
+//!   backend.
+//!
+//! - [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0): Worst performance for
+//!   degenerate seed configurations (measured up to 109% slower than `rug`)
+//!
+//! - [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only): Slightly faster than the
+//!   `dashu` backend (up to 30% slower than `rug`).
+//!
+//! - [`rug`](https://crates.io/crates/rug) (LGPL-3.0+): The fastest backend, but depends on GNU GMP
+//!   via the `gmp-mpfr-sys` crate which requires a C compiler to build and hence has the slowest
+//!   build time.
 //!
 //! # Cargo Features
 #![doc = document_features::document_features!()]
 
 #[cfg(any(
-    all(feature = "rug", feature = "malachite"),
-    all(feature = "rug", feature = "malachite-base"),
-    all(feature = "rug", feature = "malachite-nz"),
-    all(feature = "dashu", feature = "malachite"),
-    all(feature = "dashu", feature = "malachite-base"),
-    all(feature = "dashu", feature = "malachite-nz"),
+    all(feature = "malachite", feature = "rug"),
+    all(feature = "malachite", feature = "dashu"),
+    all(feature = "malachite", feature = "num_bigint"),
+    all(feature = "malachite", feature = "ibig"),
+    all(feature = "malachite-base", feature = "rug"),
+    all(feature = "malachite-base", feature = "dashu"),
+    all(feature = "malachite-base", feature = "num_bigint"),
+    all(feature = "malachite-base", feature = "ibig"),
+    all(feature = "malachite-nz", feature = "rug"),
+    all(feature = "malachite-nz", feature = "dashu"),
+    all(feature = "malachite-nz", feature = "num_bigint"),
+    all(feature = "malachite-nz", feature = "ibig"),
     all(feature = "rug", feature = "dashu"),
+    all(feature = "rug", feature = "num_bigint"),
+    all(feature = "rug", feature = "ibig"),
+    all(feature = "dashu", feature = "num_bigint"),
+    all(feature = "dashu", feature = "ibig"),
+    all(feature = "num_bigint", feature = "ibig"),
 ))]
-compile_error!("Illegal feature combination selected");
+compile_error!("Multiple arbitrary precision arithmetic backends enabled!");
 
 mod bounding_sphere;
 pub mod geometry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! # Integer Arithmetic Backend
 //!
-//! You can select from three backends for arbitrary precision integer arithmetic.
+//! You can select from five backends for arbitrary precision integer arithmetic.
 //! These all provide identical functionality and vary only in performance and licensing.
 //!
 //! For most practical applications, the choice of backend does not significantly alter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,66 @@
-//! **An implementation of the [Meshless Voronoi algorithm](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf) in rust.**
+//! **An implementation of the
+//! [Meshless Voronoi algorithm](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf)
+//! in Rust.**
 //!
-//! The algorithm is primarily aimed at generating 3D Voronoi diagrams, but can also be used to compute 1D and 2D Voronoi diagrams.
-//! Like Voro++, this algorithm is _meshless_ implying that no global geometry is constructed. Instead a cell based approach is used and we only compute integrals (cell/face volumes and centroids) and connectivity information (it is possible to determine a cell's neighbours).
+//! The algorithm is primarily aimed at generating 3D
+//! [Voronoi diagrams](https://en.wikipedia.org/wiki/Voronoi_diagram), but can
+//! also be used to compute 1D and 2D Voronoi diagrams.
 //!
-//! The algorithm can generate Voronoi tesselations with a rectangular boundary or periodic boundary conditions and also supports computing a subset of the Voronoi tesselation.
+//! Like [`Voro++`](https://math.lbl.gov/voro++/), this algorithm is *meshless*
+//! implying that no global geometry is constructed. Instead a cell-based
+//! approach is used and we only compute integrals (cell/face volumes and
+//! centroids) and connectivity information (it is possible to determine a
+//! cell's neighbours).
 //!
-//! If necessary, arbitrary precision arithmetic is used to treat degeneracies and to ensure globaly consistent local geometry, see the appendix of [this reference](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf) for more info:
-//! > <cite>Nicolas Ray, Dmitry Sokolov, Sylvain Lefebvre, Bruno Lévy. Meshless Voronoi on the GPU. ACM
-//! > Transactions on Graphics, 2018, 37 (6), pp.1-12.  10.1145/3272127.3275092 .  hal-01927559<cite>
+//! The algorithm can generate Voronoi tessellations with a rectangular boundary
+//! or periodic boundary conditions and also supports computing a subset of the
+//! Voronoi tessellation.
 //!
-//! **Features**:
+//! If necessary, arbitrary precision arithmetic is used to treat degeneracies
+//! and to ensure globally consistent local geometry. See the appendix of [this
+//! reference](https://hal.inria.fr/hal-01927559/file/voroGPU.pdf) for more
+//! info:
+//!
+//! > <cite>Nicolas Ray, Dmitry Sokolov, Sylvain Lefebvre, Bruno Lévy. Meshless
+//! > Voronoi on the GPU. ACM Transactions on Graphics, 2018, 37 (6), pp.1-12.
+//! > 10.1145/3272127.3275092. hal-01927559</cite>
+//!
+//! # Features
+//!
 //! - Construction of 1D, 2D and 3D Voronoi grids.
+//!
 //! - Partial construction of grids.
-//! - Parallel construction of the voronoi grid (requires `rayon` feature)
-//! - Save Voronoi grids to `.hdf5` format (requires `hdf5` feature)
-//! - Evaluation of custom _integrals_ for cells (e.g. weighted centroid) and faces (e.g. solid angles).
+//!
+//! - Parallel construction of the Voronoi grid.
+//!
+//! - Saving Voronoi grids to [HDF5 format](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5).
+//!
+//! - Evaluation of *custom integrals* for cells (e.g. weighted centroid) and
+//!   faces (e.g. solid angles).
+//!
+//! # Cargo Features
+#![doc = document_features::document_features!()]
+
+#[cfg(any(
+    all(feature = "rug", feature = "malachite"),
+    all(feature = "rug", feature = "malachite-base"),
+    all(feature = "rug", feature = "malachite-nz"),
+))]
+compile_error!("Illegal feature combination selected");
 
 mod bounding_sphere;
 pub mod geometry;
 mod part;
 mod rtree_nn;
 mod simple_cycle;
-// Space is no longer used, I left it in as a reference for the gpu implementation
+// Space is no longer used, I left it in as a reference for the gpu
+// implementation
 #[allow(dead_code)]
 mod space;
 mod util;
 mod voronoi;
 
-pub use voronoi::integrals;
-pub use voronoi::{ConvexCell, Voronoi, VoronoiCell, VoronoiFace, VoronoiIntegrator};
+pub use voronoi::{integrals, ConvexCell, Voronoi, VoronoiCell, VoronoiFace, VoronoiIntegrator};
 
-// pub use voronoi::integrals::{AreaIntegral, CellIntegral, FaceIntegral, VolumeIntegral};
+// pub use voronoi::integrals::{AreaIntegral, CellIntegral, FaceIntegral,
+// VolumeIntegral};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,20 +40,33 @@
 //!
 //! # Integer Arithmetic Backend
 //!
-//! The default backend for arbitrary precision integer arithemtic is
-//! [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0).
-//! For most use cases there is no significant performance difference between the different
-//! backends and `num_bigint` is the fastest to build.
+//! You can select from three backends for arbitrary precision integer
+//! arithmetic.
 //!
-//! However, for highly degenerate seed configurations, it is recommended to use the alternative
-//! [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) backend, which can increase performance
-//! up to 2x in these cases.
-//! It should be noted that this backend requires a C compiler to build and hence has the slowest build time.
+//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0) runs the test
+//!   suit at the same speed as `rug`. This is the default backend.
 //!
-//! *Using the `rug` backend also changes the license of the crate to LGPL-3.0+.*
+//! - [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only) runs the
+//!   test suite about 6% slower than `rug` but builds considerably faster.
+//!
+//! - [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) runs the test suite
+//!   faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
+//!   crate which requires a C compiler to build and has the slowest build time
+//!   thus.
 //!
 //! # Cargo Features
 #![doc = document_features::document_features!()]
+
+#[cfg(any(
+    all(feature = "rug", feature = "malachite"),
+    all(feature = "rug", feature = "malachite-base"),
+    all(feature = "rug", feature = "malachite-nz"),
+    all(feature = "dashu", feature = "malachite"),
+    all(feature = "dashu", feature = "malachite-base"),
+    all(feature = "dashu", feature = "malachite-nz"),
+    all(feature = "rug", feature = "dashu"),
+))]
+compile_error!("Illegal feature combination selected");
 
 mod bounding_sphere;
 pub mod geometry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,17 +55,6 @@
 //! # Cargo Features
 #![doc = document_features::document_features!()]
 
-#[cfg(any(
-    all(feature = "rug", feature = "malachite"),
-    all(feature = "rug", feature = "malachite-base"),
-    all(feature = "rug", feature = "malachite-nz"),
-    all(feature = "dashu", feature = "malachite"),
-    all(feature = "dashu", feature = "malachite-base"),
-    all(feature = "dashu", feature = "malachite-nz"),
-    all(feature = "rug", feature = "dashu"),
-))]
-compile_error!("Illegal feature combination selected");
-
 mod bounding_sphere;
 pub mod geometry;
 mod part;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,3 @@ mod util;
 mod voronoi;
 
 pub use voronoi::{integrals, ConvexCell, Voronoi, VoronoiCell, VoronoiFace, VoronoiIntegrator};
-
-// pub use voronoi::integrals::{AreaIntegral, CellIntegral, FaceIntegral,
-// VolumeIntegral};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,16 +40,16 @@
 //!
 //! # Integer Arithmetic Backend
 //!
-//! The default backend for arbitrary precision integer arithemtic is 
+//! The default backend for arbitrary precision integer arithemtic is
 //! [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0).
-//! For most use cases there is no significant performance difference between the different 
+//! For most use cases there is no significant performance difference between the different
 //! backends and `num_bigint` is the fastest to build.
-//! 
-//! However, for highly degenerate seed configurations, it is recommended to use the alternative 
-//! [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) backend, which can increase performance 
+//!
+//! However, for highly degenerate seed configurations, it is recommended to use the alternative
+//! [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) backend, which can increase performance
 //! up to 2x in these cases.
 //! It should be noted that this backend requires a C compiler to build and hence has the slowest build time.
-//! 
+//!
 //! *Using the `rug` backend also changes the license of the crate to LGPL-3.0+.*
 //!
 //! # Cargo Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,19 +40,17 @@
 //!
 //! # Integer Arithmetic Backend
 //!
-//! You can select from three backends for arbitrary precision integer
-//! arithmetic.
-//!
-//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0) runs the test
-//!   suit at the same speed as `rug`. This is the default backend.
-//!
-//! - [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only) runs the
-//!   test suite about 6% slower than `rug` but builds considerably faster.
-//!
-//! - [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) runs the test suite
-//!   faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
-//!   crate which requires a C compiler to build and has the slowest build time
-//!   thus.
+//! The default backend for arbitrary precision integer arithemtic is 
+//! [`num_bigint`](https://crates.io/crates/num-bigint) (MIT/Apache 2.0).
+//! For most use cases there is no significant performance difference between the different 
+//! backends and `num_bigint` is the fastest to build.
+//! 
+//! However, for highly degenerate seed configurations, it is recommended to use the alternative 
+//! [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) backend, which can increase performance 
+//! up to 2x in these cases.
+//! It should be noted that this backend requires a C compiler to build and hence has the slowest build time.
+//! 
+//! *Using the `rug` backend also changes the license of the crate to LGPL-3.0+.*
 //!
 //! # Cargo Features
 #![doc = document_features::document_features!()]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,22 @@
 //! - Evaluation of *custom integrals* for cells (e.g. weighted centroid) and
 //!   faces (e.g. solid angles).
 //!
+//! # Integer Arithmetic Backend
+//!
+//! You can select from three backends for arbitrary precision integer
+//! arithmetic.
+//!
+//! - [`dashu`](https://crates.io/crates/dashu) (MIT/Apache 2.0) runs the test
+//!   suit at the same speed as `rug`. This is the default backend.
+//!
+//! - [`malachite`](https://crates.io/crates/malachite) (LGPL-3.0-only) runs the
+//!   test suite about 6% slower than `rug` but builds considerably faster.
+//!
+//! - [`rug`](https://crates.io/crates/rug) (LGPL-3.0+) runs the test suite
+//!   faster than `malachite` but depends on GNU GMP via the `gmp-mpfr-sys`
+//!   crate which requires a C compiler to build and has the slowest build time
+//!   thus.
+//!
 //! # Cargo Features
 #![doc = document_features::document_features!()]
 
@@ -45,6 +61,10 @@
     all(feature = "rug", feature = "malachite"),
     all(feature = "rug", feature = "malachite-base"),
     all(feature = "rug", feature = "malachite-nz"),
+    all(feature = "dashu", feature = "malachite"),
+    all(feature = "dashu", feature = "malachite-base"),
+    all(feature = "dashu", feature = "malachite-nz"),
+    all(feature = "rug", feature = "dashu"),
 ))]
 compile_error!("Illegal feature combination selected");
 

--- a/src/part.rs
+++ b/src/part.rs
@@ -8,11 +8,7 @@ pub struct Part {
 
 impl Part {
     pub fn new(x: DVec3, cid: usize, pid: usize) -> Self {
-        Self {
-            x,
-            cid,
-            id: pid,
-        }
+        Self { x, cid, id: pid }
     }
 
     pub fn cid(&self) -> usize {

--- a/src/part.rs
+++ b/src/part.rs
@@ -8,7 +8,11 @@ pub struct Part {
 
 impl Part {
     pub fn new(x: DVec3, cid: usize, pid: usize) -> Self {
-        Self { x, cid, id: pid }
+        Self {
+            x,
+            cid,
+            id: pid,
+        }
     }
 
     pub fn cid(&self) -> usize {

--- a/src/rtree_nn.rs
+++ b/src/rtree_nn.rs
@@ -205,7 +205,10 @@ where
 {
     fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
         // Inverse comparison creates a min heap
-        other.distance.partial_cmp(&self.distance).expect("Distances to RTree nodes must be finite")
+        other
+            .distance
+            .partial_cmp(&self.distance)
+            .expect("Distances to RTree nodes must be finite")
     }
 }
 

--- a/src/rtree_nn.rs
+++ b/src/rtree_nn.rs
@@ -13,11 +13,7 @@ pub fn nn_iter<'a>(
     rtree: &'a RTree<Generator>,
     loc: DVec3,
 ) -> Box<dyn Iterator<Item = (usize, Option<DVec3>)> + 'a> {
-    Box::new(
-        rtree
-            .nearest_neighbor_iter(&[loc.x, loc.y, loc.z])
-            .map(|g| (g.id(), None)),
-    )
+    Box::new(rtree.nearest_neighbor_iter(&[loc.x, loc.y, loc.z]).map(|g| (g.id(), None)))
 }
 
 pub(crate) fn wrapping_nn_iter<'a>(
@@ -76,7 +72,8 @@ impl<'a> RTreeWrappingNearestNeighbourIter<'a, Generator> {
             query_point,
         };
 
-        // Add the children of this node to the heap and also shifted versions of it for all directions
+        // Add the children of this node to the heap and also shifted versions of it for
+        // all directions
         let j_range = match dimensionality {
             Dimensionality::Dimensionality2D | Dimensionality::Dimensionality3D => -1..=1,
             Dimensionality::Dimensionality1D => 0..=0,
@@ -88,11 +85,7 @@ impl<'a> RTreeWrappingNearestNeighbourIter<'a, Generator> {
         for i in -1..=1 {
             for j in j_range.clone() {
                 for k in k_range.clone() {
-                    let shift = [
-                        i as f64 * width[0],
-                        j as f64 * width[1],
-                        k as f64 * width[2],
-                    ];
+                    let shift = [i as f64 * width[0], j as f64 * width[1], k as f64 * width[2]];
                     result.extend_heap(root.children(), shift);
                 }
             }

--- a/src/rtree_nn.rs
+++ b/src/rtree_nn.rs
@@ -1,9 +1,7 @@
-use std::collections::BinaryHeap;
-
+use crate::voronoi::{Dimensionality, Generator};
 use glam::DVec3;
 use rstar::{Envelope, ParentNode, Point, PointDistance, RTree, RTreeNode, RTreeObject, AABB};
-
-use crate::voronoi::{Dimensionality, Generator};
+use std::collections::BinaryHeap;
 
 pub(crate) fn build_rtree(generators: &[Generator]) -> RTree<Generator> {
     RTree::bulk_load(generators.to_vec())
@@ -75,12 +73,12 @@ impl<'a> RTreeWrappingNearestNeighbourIter<'a, Generator> {
         // Add the children of this node to the heap and also shifted versions of it for
         // all directions
         let j_range = match dimensionality {
-            Dimensionality::Dimensionality2D | Dimensionality::Dimensionality3D => -1..=1,
-            Dimensionality::Dimensionality1D => 0..=0,
+            Dimensionality::TwoD | Dimensionality::ThreeD => -1..=1,
+            Dimensionality::OneD => 0..=0,
         };
         let k_range = match dimensionality {
-            Dimensionality::Dimensionality3D => -1..=1,
-            Dimensionality::Dimensionality1D | Dimensionality::Dimensionality2D => 0..=0,
+            Dimensionality::ThreeD => -1..=1,
+            Dimensionality::OneD | Dimensionality::TwoD => 0..=0,
         };
         for i in -1..=1 {
             for j in j_range.clone() {

--- a/src/rtree_nn.rs
+++ b/src/rtree_nn.rs
@@ -193,8 +193,7 @@ where
     T: WrappingPointDistance,
 {
     fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
-        // Inverse comparison creates a min heap
-        other.distance.partial_cmp(&self.distance)
+        Some(self.cmp(other))
     }
 }
 
@@ -205,7 +204,8 @@ where
     T: WrappingPointDistance,
 {
     fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        // Inverse comparison creates a min heap
+        other.distance.partial_cmp(&self.distance).expect("Distances to RTree nodes must be finite")
     }
 }
 

--- a/src/simple_cycle.rs
+++ b/src/simple_cycle.rs
@@ -106,14 +106,7 @@ mod test {
 
     #[test]
     fn test_extend() {
-        let mut tris = vec![
-            (2, 4, 1),
-            (1, 5, 2),
-            (5, 1, 3),
-            (5, 3, 6),
-            (3, 4, 6),
-            (4, 3, 1),
-        ];
+        let mut tris = [(2, 4, 1), (1, 5, 2), (5, 1, 3), (5, 3, 6), (3, 4, 6), (4, 3, 1)];
 
         let mut boundary = SimpleCycle::new(7);
         boundary.init(tris[0].0, tris[0].1, tris[0].2);

--- a/src/space.rs
+++ b/src/space.rs
@@ -1,8 +1,7 @@
-use glam::{DVec3, UVec3};
-use std::cmp::{Ord, Ordering};
-use std::collections::BinaryHeap;
-
 use crate::part::Part;
+
+use glam::{DVec3, UVec3};
+use std::{cmp::Ordering, collections::BinaryHeap};
 
 struct Cell {
     loc: DVec3,
@@ -12,7 +11,8 @@ struct Cell {
 }
 
 impl Cell {
-    /// Closest point within a cell to a given point. If the point is in the cell, the point itself is returned.
+    /// Closest point within a cell to a given point. If the point is in the
+    /// cell, the point itself is returned.
     fn closest_loc(&self, pos: DVec3) -> DVec3 {
         let mut res = self.loc;
 
@@ -33,7 +33,8 @@ impl Cell {
         self.closest_loc(pos).distance_squared(pos)
     }
 
-    /// The minimal distance to the faces of a cell from a point within that cell.
+    /// The minimal distance to the faces of a cell from a point within that
+    /// cell.
     fn min_distance_to_face(&self, pos: DVec3) -> f64 {
         (pos.x - self.loc.x)
             .min(self.loc.x + self.width.x - pos.x)
@@ -105,15 +106,13 @@ impl Space {
                 let i = (rel_pos.x / self.width.x * self.cdim.x as f64).floor() as i32;
                 let j = (rel_pos.y / self.width.y * self.cdim.y as f64).floor() as i32;
                 let k = (rel_pos.z / self.width.z * self.cdim.z as f64).floor() as i32;
-                let cid = self
-                    .get_cid(i, j, k)
-                    .expect("Index out of bounds during construction!");
+                let cid = self.get_cid(i, j, k).expect("Index out of bounds during construction!");
                 Part::new(*p_x, cid, pid)
             })
             .collect();
 
         // sort by cid
-        parts.sort_by(|p_a, p_b| p_a.cid().cmp(&p_b.cid()));
+        parts.sort_by_key(|p_a| p_a.cid());
 
         // add parts to space and set cell offsets and counts
         let mut offset = 0;
@@ -136,7 +135,8 @@ impl Space {
     }
 
     pub fn knn(&self, k: usize) -> Vec<Vec<usize>> {
-        /// HeapEntry struct used to build MaxHeap of nearest neighbours of particles.
+        /// HeapEntry struct used to build MaxHeap of nearest neighbours of
+        /// particles.
         #[derive(PartialEq)]
         struct HeapEntry {
             idx: usize,
@@ -227,12 +227,12 @@ impl Space {
                 r += 1;
             }
 
-            // now collect the particles nearest neighbours from the MaxHeap in increasing distance
+            // now collect the particles nearest neighbours from the MaxHeap in increasing
+            // distance
             debug_assert_eq!(h.len(), k);
             for i in (0..k).rev() {
-                let entry = h
-                    .pop()
-                    .expect("We should be able to pop k entries from a Heap of length k");
+                let entry =
+                    h.pop().expect("We should be able to pop k entries from a Heap of length k");
                 nn[part.id()][i] = entry.idx;
             }
         }
@@ -385,7 +385,8 @@ mod tests {
             // Get max distance to knn
             let max_d_2 = part.distance_squared(&space.parts[nn[k - 1]]);
 
-            // loop over the other parts and check that they are either in the nearest neighbours or farther away than max_d_2
+            // loop over the other parts and check that they are either in the nearest
+            // neighbours or farther away than max_d_2
             for (j, other) in space.parts.iter().enumerate() {
                 if j == i {
                     continue;

--- a/src/space.rs
+++ b/src/space.rs
@@ -1,5 +1,4 @@
 use crate::part::Part;
-
 use glam::{DVec3, UVec3};
 use std::{cmp::Ordering, collections::BinaryHeap};
 

--- a/src/space.rs
+++ b/src/space.rs
@@ -152,7 +152,9 @@ impl Space {
 
         impl Ord for HeapEntry {
             fn cmp(&self, other: &Self) -> Ordering {
-                self.d_2.partial_cmp(&other.d_2).expect("HeapEntries must have finite distances")
+                self.d_2
+                    .partial_cmp(&other.d_2)
+                    .expect("HeapEntries must have finite distances")
             }
         }
 

--- a/src/space.rs
+++ b/src/space.rs
@@ -146,13 +146,13 @@ impl Space {
 
         impl PartialOrd for HeapEntry {
             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                self.d_2.partial_cmp(&other.d_2)
+                Some(self.cmp(other))
             }
         }
 
         impl Ord for HeapEntry {
             fn cmp(&self, other: &Self) -> Ordering {
-                self.partial_cmp(other).unwrap()
+                self.d_2.partial_cmp(&other.d_2).expect("HeapEntries must have finite distances")
             }
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,8 @@ pub trait GetMutMultiple {
     type Output;
 
     /// Creates mutable references to elements at 3 indices `i`, `j` and `k`.
-    /// These indices are assumed to be distinct, but this is not checked by this function!
+    /// These indices are assumed to be distinct, but this is not checked by
+    /// this function!
     unsafe fn get_3_mut_unchecked(
         &mut self,
         i: usize,
@@ -10,7 +11,8 @@ pub trait GetMutMultiple {
         k: usize,
     ) -> (&mut Self::Output, &mut Self::Output, &mut Self::Output);
 
-    /// Creates mutable references to elements at 3 indices `i`, `j` and `k`, after checking that the indices are indeed all different.
+    /// Creates mutable references to elements at 3 indices `i`, `j` and `k`,
+    /// after checking that the indices are indeed all different.
     fn get_3_mut(
         &mut self,
         i: usize,

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -345,7 +345,7 @@ impl Voronoi {
                 f64,
                 total_volume,
                 box_volume,
-                epsilon = box_volume * 1e-13,
+                epsilon = box_volume * 1e-12,
                 ulps = 4
             );
         }

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -350,7 +350,7 @@ impl Voronoi {
                 f64,
                 total_volume,
                 box_volume,
-                epsilon = box_volume * 1e-12,
+                epsilon = box_volume * 1e-11,
                 ulps = 4
             );
         }
@@ -866,7 +866,7 @@ mod test {
     #[test]
     fn test_3_d() {
         let pert = 0.95;
-        let count = 75;
+        let count = 60;
         let anchor = DVec3::ZERO;
         let width = DVec3::splat(2.);
         let generators = perturbed_grid(anchor, width, count, pert);

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -48,7 +48,9 @@ impl Dimensionality {
 #[allow(unused)]
 macro_rules! unravel {
     ($array:expr, $n:expr) => {
-        (0..$n).map(|i| $array.iter().take(i).step_by($n).map(|v| *v).collect()).collect()
+        (0..$n)
+            .map(|i| $array.iter().take(i).step_by($n).map(|v| *v).collect())
+            .collect()
     };
 }
 
@@ -60,7 +62,10 @@ macro_rules! flatten {
 
 macro_rules! cells_map {
     ($cells:expr, $mappable:expr) => {
-        $cells.iter().filter_map(|maybe_cell| maybe_cell.as_ref().map($mappable)).collect()
+        $cells
+            .iter()
+            .filter_map(|maybe_cell| maybe_cell.as_ref().map($mappable))
+            .collect()
     };
 }
 
@@ -363,8 +368,11 @@ impl Voronoi {
         let group = file.create_group("Cells")?;
         let data = self.voronoi_cells.iter().map(|c| c.volume()).collect::<Vec<_>>();
         group.new_dataset_builder().with_data(&data).create("Volume")?;
-        let data =
-            self.voronoi_cells.iter().map(|c| c.face_connections_offset()).collect::<Vec<_>>();
+        let data = self
+            .voronoi_cells
+            .iter()
+            .map(|c| c.face_connections_offset())
+            .collect::<Vec<_>>();
         group.new_dataset_builder().with_data(&data).create("FaceConnectionsOffset")?;
         let data = self.voronoi_cells.iter().map(|c| c.face_count()).collect::<Vec<_>>();
         group.new_dataset_builder().with_data(&data).create("FaceCount")?;
@@ -954,14 +962,7 @@ mod test {
         let volume_centroids = integrator.compute_cell_integrals::<VolumeCentroidIntegrator>();
 
         assert_eq!(area_centroids.len(), 1);
-        for (
-            i,
-            AreaCentroidIntegrator {
-                area,
-                centroid,
-            },
-        ) in area_centroids[0].iter().enumerate()
-        {
+        for (i, AreaCentroidIntegrator { area, centroid }) in area_centroids[0].iter().enumerate() {
             assert_eq!(*area, voronoi.faces()[i].area());
             assert_eq!(*centroid, voronoi.faces()[i].centroid());
         }

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -866,7 +866,7 @@ mod test {
     #[test]
     fn test_3_d() {
         let pert = 0.95;
-        let count = 60;
+        let count = 15;
         let anchor = DVec3::ZERO;
         let width = DVec3::splat(2.);
         let generators = perturbed_grid(anchor, width, count, pert);

--- a/src/voronoi/boundary.rs
+++ b/src/voronoi/boundary.rs
@@ -20,13 +20,11 @@ impl SimulationBoundary {
         if periodic {
             anchor.x -= width.x;
             width.x *= 3.;
-            if let Dimensionality::Dimensionality2D | Dimensionality::Dimensionality3D =
-                dimensionality
-            {
+            if let Dimensionality::TwoD | Dimensionality::ThreeD = dimensionality {
                 anchor.y -= width.y;
                 width.y *= 3.;
             };
-            if let Dimensionality::Dimensionality3D = dimensionality {
+            if let Dimensionality::ThreeD = dimensionality {
                 anchor.z -= width.z;
                 width.z *= 3.;
             }

--- a/src/voronoi/boundary.rs
+++ b/src/voronoi/boundary.rs
@@ -53,10 +53,6 @@ impl SimulationBoundary {
         let loc = DVec3::splat(1.) + (loc - self.anchor) * self.inverse_width;
         // convert to bits, only mantissa should have nonzero bits at this point,
         // so these numbers can be interpreted as rescaled u64 integer coordinates
-        [
-            loc.x.to_bits() as i64,
-            loc.y.to_bits() as i64,
-            loc.z.to_bits() as i64,
-        ]
+        [loc.x.to_bits() as i64, loc.y.to_bits() as i64, loc.z.to_bits() as i64]
     }
 }

--- a/src/voronoi/convex_cell.rs
+++ b/src/voronoi/convex_cell.rs
@@ -2,13 +2,11 @@ use super::{
     boundary::SimulationBoundary, convex_cell_alternative::ConvexCell as ConvexCellAlternative,
     half_space::HalfSpace, Dimensionality, Generator,
 };
-
 use crate::{
     geometry::{in_sphere_test_exact, intersect_planes, Plane},
     integrals::{CellIntegralWithData, FaceIntegralWithData},
     simple_cycle::SimpleCycle,
 };
-
 use glam::DVec3;
 
 /// A vertex of a [`ConvexCell`].
@@ -40,9 +38,9 @@ impl Vertex {
         let loc =
             intersect_planes(&half_spaces[i].plane, &half_spaces[j].plane, &half_spaces[k].plane);
         let d_loc = match dimensionality {
-            Dimensionality::Dimensionality1D => DVec3::new(loc.x, 0., 0.),
-            Dimensionality::Dimensionality2D => DVec3::new(loc.x, loc.y, 0.),
-            Dimensionality::Dimensionality3D => loc,
+            Dimensionality::OneD => DVec3::new(loc.x, 0., 0.),
+            Dimensionality::TwoD => DVec3::new(loc.x, loc.y, 0.),
+            Dimensionality::ThreeD => loc,
         };
         Vertex {
             loc,
@@ -457,7 +455,7 @@ impl From<ConvexCellAlternative> for ConvexCell {
                     v.repr.2,
                     &clipping_planes,
                     convex_cell_alt.loc,
-                    Dimensionality::Dimensionality3D,
+                    Dimensionality::ThreeD,
                 )
             })
             .collect::<Vec<_>>();
@@ -478,13 +476,11 @@ impl From<ConvexCellAlternative> for ConvexCell {
 mod test {
     use super::*;
 
-    const DIM3D: usize = 3;
-
     #[test]
     fn test_init_cuboid() {
         let anchor = DVec3::splat(1.);
         let width = DVec3::splat(4.);
-        let cell = SimulationBoundary::cuboid(anchor, width, false, DIM3D.into());
+        let cell = SimulationBoundary::cuboid(anchor, width, false, Dimensionality::ThreeD.into());
 
         assert_eq!(cell.clipping_planes.len(), 6);
     }
@@ -494,12 +490,15 @@ mod test {
         let anchor = DVec3::splat(1.);
         let width = DVec3::splat(2.);
         let loc = DVec3::splat(2.);
-        let volume = SimulationBoundary::cuboid(anchor, width, false, DIM3D.into());
+        let volume =
+            SimulationBoundary::cuboid(anchor, width, false, Dimensionality::ThreeD.into());
         let mut cell = ConvexCell::init(loc, 0, &volume);
 
         let ngb = DVec3::splat(2.5);
-        let generators =
-            [Generator::new(0, loc, DIM3D.into()), Generator::new(1, ngb, DIM3D.into())];
+        let generators = [
+            Generator::new(0, loc, Dimensionality::ThreeD.into()),
+            Generator::new(1, ngb, Dimensionality::ThreeD.into()),
+        ];
         let dx = cell.loc - ngb;
         let dist = dx.length();
         let n = dx / dist;

--- a/src/voronoi/convex_cell.rs
+++ b/src/voronoi/convex_cell.rs
@@ -147,12 +147,12 @@ impl Iterator for ConvexCellDecomposition<'_> {
 }
 
 /// Meshless representation of a Voronoi cell as an intersection of
-/// [`HalfSpace`]s.
+/// half-spaces.
 ///
 /// Can be used to compute integrated cell and face quantities.
 #[derive(Clone, Debug)]
 pub struct ConvexCell {
-    /// The location of the generator of this `ConvexCell`/[`VoronoiCell`].
+    /// The location of the generator of this `ConvexCell`/`VoronoiCell`.
     pub loc: DVec3,
     /// [`Halfspace`]s that intersect to form this `ConvexCell`. Their normals
     /// are pointed inwards.
@@ -160,6 +160,7 @@ pub struct ConvexCell {
     pub(super) vertices: Vec<Vertex>,
     boundary: SimpleCycle,
     pub(super) safety_radius: f64,
+    /// The index (label) of the generator of this `ConvexCell`/`VoronoiCell`
     pub idx: usize,
     pub(super) dimensionality: Dimensionality,
 }

--- a/src/voronoi/convex_cell.rs
+++ b/src/voronoi/convex_cell.rs
@@ -1,4 +1,7 @@
-use glam::DVec3;
+use super::{
+    boundary::SimulationBoundary, convex_cell_alternative::ConvexCell as ConvexCellAlternative,
+    half_space::HalfSpace, Dimensionality, Generator,
+};
 
 use crate::{
     geometry::{in_sphere_test_exact, intersect_planes, Plane},
@@ -6,20 +9,18 @@ use crate::{
     simple_cycle::SimpleCycle,
 };
 
-use super::{
-    boundary::SimulationBoundary,
-    convex_cell_alternative::ConvexCell as ConvexCellAlternative,
-    half_space::HalfSpace,
-    Dimensionality, Generator,
-};
+use glam::DVec3;
 
-/// A Vertex of a convex cell.
+/// A vertex of a [`ConvexCell`].
 ///
 /// Stores:
-/// - the location of the vertex
-/// - its dual representation: the indices of the three half spaces that intersect at the vertex
-///   (in counterclockwise order around the vertex).
-/// - the safety radius for this vertex.
+///
+/// - The location of the vertex.
+///
+/// - Its dual representation: the indices of the three half spaces that
+///   intersect at the vertex (in counterclockwise order around the vertex).
+///
+/// - The safety radius for this vertex.
 #[derive(Clone, Debug)]
 pub(super) struct Vertex {
     pub loc: DVec3,
@@ -36,11 +37,8 @@ impl Vertex {
         gen_loc: DVec3,
         dimensionality: Dimensionality,
     ) -> Self {
-        let loc = intersect_planes(
-            &half_spaces[i].plane,
-            &half_spaces[j].plane,
-            &half_spaces[k].plane,
-        );
+        let loc =
+            intersect_planes(&half_spaces[i].plane, &half_spaces[j].plane, &half_spaces[k].plane);
         let d_loc = match dimensionality {
             Dimensionality::Dimensionality1D => DVec3::new(loc.x, 0., 0.),
             Dimensionality::Dimensionality2D => DVec3::new(loc.x, loc.y, 0.),
@@ -54,14 +52,19 @@ impl Vertex {
     }
 }
 
-/// An oriented tetrahedron, part of a decomposition of a ConvexCell.
-/// The generator of the corresponding ConvexCell is forms the top of the tetrahedron.
+/// An oriented tetrahedron, part of a decomposition of a [`ConvexCell`].
+/// The generator of the corresponding [`ConvexCell`] is forms the top of the
+/// tetrahedron.
 ///
 /// We use the following orientation convention:
-/// - If the three vertices are ordered counterclockwise as seen from the top, the tetrahedron is assumed to be part of
-///   the ConvexCell and should contribute from any integrals that will be computed.
-/// - If the vertices are ordered clockwise, the tetrahedron should substract from the integrals,
-///   to correct for another tetrahedron that was not fully contained within the ConvexCell.
+///
+/// - If the three vertices are ordered counterclockwise as seen from the top,
+///   the tetrahedron is assumed to be part of the `ConvexCell` and should
+///   contribute from any integrals that will be computed.
+///
+/// - If the vertices are ordered clockwise, the tetrahedron should subtract
+///   from the integrals, to correct for another tetrahedron that was not fully
+///   contained within the `ConvexCell`.
 pub(super) struct ConvexCellTet {
     pub plane_idx: usize,
     pub vertices: [DVec3; 3],
@@ -76,9 +79,10 @@ impl ConvexCellTet {
     }
 }
 
-/// Decompose a ConvexCell into an iterator of oriented tetrahedra.
+/// Decompose a [`ConvexCell`] into an iterator of oriented tetrahedra.
 ///
-/// Usefull to compute integrals, such as volume, area, centroid... for ConvexCells.
+/// Useful to compute integrals, such as volume, area, centroid, etc. for
+/// [`ConvexCell`]s.
 pub(super) struct ConvexCellDecomposition<'a> {
     convex_cell: &'a ConvexCell,
     cur_vertex_idx: usize,
@@ -108,7 +112,7 @@ impl<'a> ConvexCellDecomposition<'a> {
                 &self.convex_cell.clipping_planes[self.cur_vertex.dual[(i + 1) % 3]].plane;
             self.projections[2 * i] = cur_plane.project_onto(self.convex_cell.loc);
             self.projections[2 * i + 1] =
-                next_plane.project_onto_intersection(&cur_plane, self.convex_cell.loc);
+                next_plane.project_onto_intersection(cur_plane, self.convex_cell.loc);
         }
     }
 }
@@ -144,14 +148,16 @@ impl Iterator for ConvexCellDecomposition<'_> {
     }
 }
 
-/// Meshless representation of a Voronoi cell as an intersection of halfspaces.
+/// Meshless representation of a Voronoi cell as an intersection of
+/// [`HalfSpace`]s.
 ///
-/// Can be used to compute integrated cell and face quantities
+/// Can be used to compute integrated cell and face quantities.
 #[derive(Clone, Debug)]
 pub struct ConvexCell {
-    /// The location of the generator of this ConvexCell/VoronoiCell
+    /// The location of the generator of this `ConvexCell`/[`VoronoiCell`].
     pub loc: DVec3,
-    /// Halfspaces that intersect to form this ConvexCell. Their normals are pointed inwards.
+    /// [`Halfspace`]s that intersect to form this `ConvexCell`. Their normals
+    /// are pointed inwards.
     pub(super) clipping_planes: Vec<HalfSpace>,
     pub(super) vertices: Vec<Vertex>,
     boundary: SimpleCycle,
@@ -161,7 +167,8 @@ pub struct ConvexCell {
 }
 
 impl ConvexCell {
-    /// Initialize each voronoi cell as the bounding box of the simulation volume.
+    /// Initialize each Voronoi cell as the bounding box of the simulation
+    /// volume.
     pub(super) fn init(loc: DVec3, idx: usize, simulation_boundary: &SimulationBoundary) -> Self {
         let clipping_planes = simulation_boundary.clipping_planes.clone();
 
@@ -190,7 +197,8 @@ impl ConvexCell {
         cell
     }
 
-    /// Build the Convex cell by repeatedly intersecting it with the appropriate half spaces
+    /// Build the Convex cell by repeatedly intersecting it with the appropriate
+    /// half spaces
     pub(super) fn build(
         loc: DVec3,
         idx: usize,
@@ -201,14 +209,12 @@ impl ConvexCell {
         let mut cell = ConvexCell::init(loc, idx, simulation_boundary);
         // skip the first nearest neighbour (will be this cell)
         assert_eq!(
-            nearest_neighbours
-                .next()
-                .expect("Nearest neighbours cannot be empty!")
-                .0,
+            nearest_neighbours.next().expect("Nearest neighbours cannot be empty!").0,
             cell.idx,
             "First nearest neighbour should be the generator itself!"
         );
-        // now loop over the nearest neighbours and clip this cell until the safety radius is reached
+        // now loop over the nearest neighbours and clip this cell until the safety
+        // radius is reached
         for (idx, shift) in nearest_neighbours {
             let generator = generators[idx];
             let ngb_loc;
@@ -279,15 +285,14 @@ impl ConvexCell {
             let p_idx = self.clipping_planes.len();
             self.clipping_planes.push(p);
             self.boundary.grow();
-            // Compute the boundary of the (dual) topological triangulated disk around the vertices to be removed.
+            // Compute the boundary of the (dual) topological triangulated disk around the
+            // vertices to be removed.
             Self::compute_boundary(&mut self.boundary, &mut self.vertices[num_v..]);
             let mut boundary = self.boundary.iter().take(self.boundary.len + 1);
             // finally we can *realy* remove the vertices.
             self.vertices.truncate(num_v);
             // Add new vertices constructed from the new clipping plane and the boundary
-            let mut cur = boundary
-                .next()
-                .expect("Boundary contains at least 3 elements");
+            let mut cur = boundary.next().expect("Boundary contains at least 3 elements");
             for next in boundary {
                 self.vertices.push(Vertex::from_dual(
                     cur,
@@ -304,20 +309,13 @@ impl ConvexCell {
     }
 
     fn compute_boundary(boundary: &mut SimpleCycle, vertices: &mut [Vertex]) {
-        boundary.init(
-            vertices[0].dual[0],
-            vertices[0].dual[1],
-            vertices[0].dual[2],
-        );
+        boundary.init(vertices[0].dual[0], vertices[0].dual[1], vertices[0].dual[2]);
 
         for i in 1..vertices.len() {
             // Look for a suitable next vertex to extend the boundary
             let mut idx = i;
             loop {
-                assert!(
-                    idx < vertices.len(),
-                    "No suitable vertex found to extend boundary!"
-                );
+                assert!(idx < vertices.len(), "No suitable vertex found to extend boundary!");
                 let vertex = &vertices[idx].dual;
                 match boundary.try_extend(vertex[0], vertex[1], vertex[2]) {
                     Ok(()) => {
@@ -345,23 +343,24 @@ impl ConvexCell {
     }
 
     /// Get the index of the generator on the opposite side of a clipping plane.
-    pub fn get_neighbour(&self, clipping_plane_idx: usize) -> Option<usize> {
+    pub fn neighbour(&self, clipping_plane_idx: usize) -> Option<usize> {
         self.clipping_planes[clipping_plane_idx].right_idx
     }
 
-    /// Get the shift (if any) associated with a given clipping plane (for applying periodic boundary conditions).
-    pub fn get_shift(&self, clipping_plane_idx: usize) -> Option<DVec3> {
+    /// Get the shift (if any) associated with a given clipping plane (for
+    /// applying periodic boundary conditions).
+    pub fn shift(&self, clipping_plane_idx: usize) -> Option<DVec3> {
         self.clipping_planes[clipping_plane_idx].shift
     }
 
-    pub fn get_plane(&self, clipping_plane_idx: usize) -> Plane {
+    pub fn plane(&self, clipping_plane_idx: usize) -> Plane {
         self.clipping_planes[clipping_plane_idx].plane.clone()
     }
 
     /// Compute a custom integrated quantity for this cell.
     pub fn compute_cell_integral<D: Copy, T: CellIntegralWithData<D>>(&self, extra_data: D) -> T {
         // Compute integral from decomposition of convex cell
-        let mut integrator = T::init_with_data(&self, extra_data);
+        let mut integrator = T::init_with_data(self, extra_data);
         for tet in self.decompose() {
             integrator.collect(tet.vertices[0], tet.vertices[1], tet.vertices[2], self.loc);
         }
@@ -369,11 +368,11 @@ impl ConvexCell {
     }
 
     fn clipping_plane_has_valid_dimensionality(&self, plane_idx: usize) -> bool {
-        self.dimensionality
-            .vector_is_valid(self.clipping_planes[plane_idx].normal())
+        self.dimensionality.vector_is_valid(self.clipping_planes[plane_idx].normal())
     }
 
-    /// Compute a custom integrated quantity for the faces of this cell (non-symmetric version).
+    /// Compute a custom integrated quantity for the faces of this cell
+    /// (non-symmetric version).
     pub fn compute_face_integrals<D: Copy, T: FaceIntegralWithData<D>>(
         &self,
         extra_data: D,
@@ -399,9 +398,11 @@ impl ConvexCell {
 
     /// Compute a custom integrated quantity for the faces of this cell.
     ///
-    /// Symmetric version: skips faces that are shared with active cells with a smaller idx.
+    /// Symmetric version: skips faces that are shared with active cells with a
+    /// smaller idx.
     ///
-    /// - `mask`: A mask indicating which for which generators convex_cells are actually constructed.
+    /// - `mask`: A mask indicating which for which generators convex cells are
+    ///   actually constructed.
     pub fn compute_face_integrals_sym<D: Copy, T: FaceIntegralWithData<D>>(
         &self,
         extra_data: D,
@@ -417,7 +418,8 @@ impl ConvexCell {
             let integral = &mut integrals[tet.plane_idx];
             if integral.is_none() {
                 match &self.clipping_planes[tet.plane_idx] {
-                    // If the face is no boundary face and right_idx < this cell's idx corresponds to an active cell, we already treated this face.
+                    // If the face is no boundary face and right_idx < this cell's idx corresponds
+                    // to an active cell, we already treated this face.
                     &HalfSpace {
                         shift: None,
                         right_idx: Some(right_idx),
@@ -426,7 +428,8 @@ impl ConvexCell {
                     _ => (),
                 }
             }
-            let integral = integral.get_or_insert_with(|| T::init_with_data(self, tet.plane_idx, extra_data));
+            let integral =
+                integral.get_or_insert_with(|| T::init_with_data(self, tet.plane_idx, extra_data));
             integral.collect(tet.vertices[0], tet.vertices[1], tet.vertices[2], self.loc);
         }
 
@@ -473,8 +476,6 @@ impl From<ConvexCellAlternative> for ConvexCell {
 
 #[cfg(test)]
 mod test {
-    use crate::voronoi::{boundary::SimulationBoundary, half_space::HalfSpace, Generator};
-
     use super::*;
 
     const DIM3D: usize = 3;
@@ -497,19 +498,13 @@ mod test {
         let mut cell = ConvexCell::init(loc, 0, &volume);
 
         let ngb = DVec3::splat(2.5);
-        let generators = [
-            Generator::new(0, loc, DIM3D.into()),
-            Generator::new(1, ngb, DIM3D.into()),
-        ];
+        let generators =
+            [Generator::new(0, loc, DIM3D.into()), Generator::new(1, ngb, DIM3D.into())];
         let dx = cell.loc - ngb;
         let dist = dx.length();
         let n = dx / dist;
         let p = 0.5 * (cell.loc + ngb);
-        cell.clip_by_plane(
-            HalfSpace::new(n, p, Some(1), Some(DVec3::ZERO)),
-            &generators,
-            &volume,
-        );
+        cell.clip_by_plane(HalfSpace::new(n, p, Some(1), Some(DVec3::ZERO)), &generators, &volume);
 
         assert_eq!(cell.clipping_planes.len(), 7)
     }

--- a/src/voronoi/convex_cell_alternative.rs
+++ b/src/voronoi/convex_cell_alternative.rs
@@ -22,11 +22,8 @@ impl DualVertex {
         neighbours: &[Neighbour],
         dimensionality: Dimensionality,
     ) -> Self {
-        let mut circumcenter = intersect_planes(
-            &neighbours[_0].plane,
-            &neighbours[_1].plane,
-            &neighbours[_2].plane,
-        );
+        let mut circumcenter =
+            intersect_planes(&neighbours[_0].plane, &neighbours[_1].plane, &neighbours[_2].plane);
         match dimensionality {
             Dimensionality::Dimensionality1D => {
                 circumcenter.y = 0.;
@@ -83,7 +80,8 @@ pub(super) struct ConvexCell {
 }
 
 impl ConvexCell {
-    /// Initialize each voronoi cell as the bounding box of the simulation volume.
+    /// Initialize each Voronoi cell as the bounding box of the simulation
+    /// volume.
     pub(super) fn init(
         loc: DVec3,
         idx: usize,
@@ -109,42 +107,12 @@ impl ConvexCell {
         let opposite = anchor + width;
 
         let neighbours = vec![
-            Neighbour::new(
-                DVec3::new(2. * anchor.x - loc.x, loc.y, loc.z),
-                None,
-                None,
-                loc,
-            ),
-            Neighbour::new(
-                DVec3::new(2. * opposite.x - loc.x, loc.y, loc.z),
-                None,
-                None,
-                loc,
-            ),
-            Neighbour::new(
-                DVec3::new(loc.x, 2. * anchor.y - loc.y, loc.z),
-                None,
-                None,
-                loc,
-            ),
-            Neighbour::new(
-                DVec3::new(loc.x, 2. * opposite.y - loc.y, loc.z),
-                None,
-                None,
-                loc,
-            ),
-            Neighbour::new(
-                DVec3::new(loc.x, loc.y, 2. * anchor.z - loc.z),
-                None,
-                None,
-                loc,
-            ),
-            Neighbour::new(
-                DVec3::new(loc.x, loc.y, 2. * opposite.z - loc.z),
-                None,
-                None,
-                loc,
-            ),
+            Neighbour::new(DVec3::new(2. * anchor.x - loc.x, loc.y, loc.z), None, None, loc),
+            Neighbour::new(DVec3::new(2. * opposite.x - loc.x, loc.y, loc.z), None, None, loc),
+            Neighbour::new(DVec3::new(loc.x, 2. * anchor.y - loc.y, loc.z), None, None, loc),
+            Neighbour::new(DVec3::new(loc.x, 2. * opposite.y - loc.y, loc.z), None, None, loc),
+            Neighbour::new(DVec3::new(loc.x, loc.y, 2. * anchor.z - loc.z), None, None, loc),
+            Neighbour::new(DVec3::new(loc.x, loc.y, 2. * opposite.z - loc.z), None, None, loc),
         ];
         let vertices = vec![
             DualVertex::new(2, 5, 0, loc, &neighbours, dimensionality),
@@ -169,7 +137,8 @@ impl ConvexCell {
         cell
     }
 
-    /// Build the Convex cell by repeatedly intersecting it with the appropriate half spaces
+    /// Build the Convex cell by repeatedly intersecting it with the appropriate
+    /// half spaces
     pub(super) fn build(
         &mut self,
         generators: &[Generator],
@@ -178,14 +147,12 @@ impl ConvexCell {
     ) {
         // skip the first nearest neighbour (will be this cell)
         assert_eq!(
-            nearest_neighbours
-                .next()
-                .expect("Nearest neighbours cannot be empty!")
-                .0,
+            nearest_neighbours.next().expect("Nearest neighbours cannot be empty!").0,
             self.idx,
             "First nearest neighbour should be the generator itself!"
         );
-        // now loop over the nearest neighbours and clip this cell until the safety radius is reached
+        // now loop over the nearest neighbours and clip this cell until the safety
+        // radius is reached
         for (idx, shift) in nearest_neighbours {
             let generator = generators[idx];
             let ngb_loc;
@@ -228,18 +195,16 @@ impl ConvexCell {
         // Were any vertices clipped?
         if num_r > 0 {
             let new_idx = self.neighbours.len();
-            self.neighbours
-                .push(Neighbour::new(ngb_loc, Some(ngb_idx), shift, self.loc));
+            self.neighbours.push(Neighbour::new(ngb_loc, Some(ngb_idx), shift, self.loc));
             self.boundary.grow();
-            // Compute the boundary of the (dual) topological triangulated disk around the vertices to be removed.
+            // Compute the boundary of the (dual) topological triangulated disk around the
+            // vertices to be removed.
             Self::compute_boundary(&mut self.boundary, &mut self.vertices[num_v..]);
             let mut boundary = self.boundary.iter().take(self.boundary.len + 1);
             // finally we can *realy* remove the vertices.
             self.vertices.truncate(num_v);
             // Add new vertices constructed from the new clipping plane and the boundary
-            let mut cur = boundary
-                .next()
-                .expect("Boundary contains at least 3 elements");
+            let mut cur = boundary.next().expect("Boundary contains at least 3 elements");
             for next in boundary {
                 self.vertices.push(DualVertex::new(
                     cur,
@@ -270,10 +235,7 @@ impl ConvexCell {
             // Look for a suitable next vertex to extend the boundary
             let mut idx = i;
             loop {
-                assert!(
-                    idx < vertices.len(),
-                    "No suitable vertex found to extend boundary!"
-                );
+                assert!(idx < vertices.len(), "No suitable vertex found to extend boundary!");
                 let vertex = &vertices[idx];
                 match boundary.try_extend(vertex.repr.0, vertex.repr.1, vertex.repr.2) {
                     Ok(()) => {

--- a/src/voronoi/convex_cell_alternative.rs
+++ b/src/voronoi/convex_cell_alternative.rs
@@ -15,15 +15,15 @@ pub(super) struct DualVertex {
 
 impl DualVertex {
     fn new(
-        _0: usize,
-        _1: usize,
-        _2: usize,
+        n_0: usize,
+        n_1: usize,
+        n_2: usize,
         loc: DVec3,
         neighbours: &[Neighbour],
         dimensionality: Dimensionality,
     ) -> Self {
         let mut circumcenter =
-            intersect_planes(&neighbours[_0].plane, &neighbours[_1].plane, &neighbours[_2].plane);
+            intersect_planes(&neighbours[n_0].plane, &neighbours[n_1].plane, &neighbours[n_2].plane);
         match dimensionality {
             Dimensionality::OneD => {
                 circumcenter.y = 0.;
@@ -33,7 +33,7 @@ impl DualVertex {
             Dimensionality::ThreeD => (),
         }
         Self {
-            repr: (_0, _1, _2),
+            repr: (n_0, n_1, n_2),
             circumradius2: (loc - circumcenter).length_squared(),
         }
     }

--- a/src/voronoi/convex_cell_alternative.rs
+++ b/src/voronoi/convex_cell_alternative.rs
@@ -25,12 +25,12 @@ impl DualVertex {
         let mut circumcenter =
             intersect_planes(&neighbours[_0].plane, &neighbours[_1].plane, &neighbours[_2].plane);
         match dimensionality {
-            Dimensionality::Dimensionality1D => {
+            Dimensionality::OneD => {
                 circumcenter.y = 0.;
                 circumcenter.z = 0.;
             }
-            Dimensionality::Dimensionality2D => circumcenter.z = 0.,
-            Dimensionality::Dimensionality3D => (),
+            Dimensionality::TwoD => circumcenter.z = 0.,
+            Dimensionality::ThreeD => (),
         }
         Self {
             repr: (_0, _1, _2),
@@ -93,13 +93,11 @@ impl ConvexCell {
         if periodic {
             anchor.x -= width.x;
             width.x *= 3.;
-            if let Dimensionality::Dimensionality2D | Dimensionality::Dimensionality3D =
-                dimensionality
-            {
+            if let Dimensionality::TwoD | Dimensionality::ThreeD = dimensionality {
                 anchor.y -= width.y;
                 width.y *= 3.;
             };
-            if let Dimensionality::Dimensionality3D = dimensionality {
+            if let Dimensionality::ThreeD = dimensionality {
                 anchor.z -= width.z;
                 width.z *= 3.;
             }

--- a/src/voronoi/convex_cell_alternative.rs
+++ b/src/voronoi/convex_cell_alternative.rs
@@ -22,8 +22,11 @@ impl DualVertex {
         neighbours: &[Neighbour],
         dimensionality: Dimensionality,
     ) -> Self {
-        let mut circumcenter =
-            intersect_planes(&neighbours[n_0].plane, &neighbours[n_1].plane, &neighbours[n_2].plane);
+        let mut circumcenter = intersect_planes(
+            &neighbours[n_0].plane,
+            &neighbours[n_1].plane,
+            &neighbours[n_2].plane,
+        );
         match dimensionality {
             Dimensionality::OneD => {
                 circumcenter.y = 0.;

--- a/src/voronoi/generator.rs
+++ b/src/voronoi/generator.rs
@@ -20,7 +20,10 @@ impl Generator {
             Dimensionality::Dimensionality2D => loc.z = 0.,
             _ => (),
         }
-        Self { loc, id }
+        Self {
+            loc,
+            id,
+        }
     }
 
     /// Get the id of this generator

--- a/src/voronoi/generator.rs
+++ b/src/voronoi/generator.rs
@@ -13,11 +13,11 @@ impl Generator {
     pub(super) fn new(id: usize, loc: DVec3, dimensionality: Dimensionality) -> Self {
         let mut loc = loc;
         match dimensionality {
-            Dimensionality::Dimensionality1D => {
+            Dimensionality::OneD => {
                 loc.y = 0.;
                 loc.z = 0.;
             }
-            Dimensionality::Dimensionality2D => loc.z = 0.,
+            Dimensionality::TwoD => loc.z = 0.,
             _ => (),
         }
         Self {

--- a/src/voronoi/generator.rs
+++ b/src/voronoi/generator.rs
@@ -20,10 +20,7 @@ impl Generator {
             Dimensionality::TwoD => loc.z = 0.,
             _ => (),
         }
-        Self {
-            loc,
-            id,
-        }
+        Self { loc, id }
     }
 
     /// Get the id of this generator

--- a/src/voronoi/half_space.rs
+++ b/src/voronoi/half_space.rs
@@ -15,6 +15,7 @@ pub(super) struct HalfSpace {
 
 impl HalfSpace {
     const EPSILON: f64 = 1e-13;
+
     pub fn new(n: DVec3, p: DVec3, right_idx: Option<usize>, shift: Option<DVec3>) -> Self {
         HalfSpace {
             plane: Plane::new(n, p),
@@ -26,8 +27,9 @@ impl HalfSpace {
     }
 
     /// Determine on which side of the plane a given `vertex` lies.
-    /// Returns `1.` if the `vertex` lies on the positive half space (direction of normal),
-    /// `-1.` when the `vertex` lies on the negative half space and `0.` when a more precise test is needed
+    /// Returns `1.` if the `vertex` lies on the positive half space (direction
+    /// of normal), `-1.` when the `vertex` lies on the negative half space
+    /// and `0.` when a more precise test is needed
     pub fn clip(&self, vertex: DVec3) -> f64 {
         let clip = self.plane.n.dot(vertex) - self.d;
         if clip.abs() < self.errb {

--- a/src/voronoi/integrals.rs
+++ b/src/voronoi/integrals.rs
@@ -8,30 +8,35 @@ use super::convex_cell::ConvexCell;
 
 /// Trait to implement new integrators for Voronoi cells.
 ///
-/// Integrators are expected to compute quanties of interest for Voronoi cells iteratively.
-/// The Voronoi cell is decomposed into a number of oriented tetrahedra,
-/// which are fed one by one to the cell-integrators.
+/// Integrators are expected to compute quantities of interest for Voronoi cells
+/// iteratively. The Voronoi cell is decomposed into a number of oriented
+/// tetrahedra, which are fed one by one to the cell-integrators.
 ///
 /// We use the following orientation convention:
-/// - If the three vertices are ordered counterclockwise as seen from the top, the tetrahedron is assumed to be part of
-///   the Voronoi cell and should contribute positively to integrals.
-/// - If the three vertices are ordered clockwise, the tetrahedron should substract from the integrals.
-///   this is to correct for another tetrahedron that is not fully contained within the Voronoi cell.
+///
+/// - If the three vertices are ordered counterclockwise as seen from the top,
+///   the tetrahedron is assumed to be part of the Voronoi cell and should
+///   contribute positively to integrals.
+///
+/// - If the three vertices are ordered clockwise, the tetrahedron should
+///   subtract from the integrals. this is to correct for another tetrahedron
+///   that is not fully contained within the Voronoi cell.
 pub trait CellIntegral: Sized {
-    /// Initialize a CellIntegral for the given ConvexCell.
+    /// Initialize a [`CellIntegral`] for the given [`ConvexCell`].
     fn init(cell: &ConvexCell) -> Self;
 
-    /// Update the state of the integrator using one oriented tetrahedron (with the cell's generator `gen` as top),
-    /// which is part of a cell.
+    /// Update the state of the integrator using one oriented tetrahedron (with
+    /// the cell's generator `gen` as top), which is part of a cell.
     fn collect(&mut self, v0: DVec3, v1: DVec3, v2: DVec3, gen: DVec3);
 
     /// Finalize the calculation and return the result
     fn finalize(self) -> Self;
 }
 
-/// Trait to implement new integrators that use external data in their calculation.
+/// Trait to implement new integrators that use external data in their
+/// calculation.
 pub trait CellIntegralWithData<D: Copy>: CellIntegral {
-    /// Initialize a CellIntegral with some extra data.
+    /// Initialize a [`CellIntegral`] with some extra data.
     fn init_with_data(cell: &ConvexCell, data: D) -> Self;
 }
 
@@ -78,7 +83,8 @@ impl CellIntegral for VolumeCentroidIntegrator {
     }
 }
 
-/// Example implementation of a simple cell integrator for computing the volume of a ConvexCell
+/// Example implementation of a simple cell integrator for computing the volume
+/// of a [`ConvexCell`].
 #[derive(Default)]
 pub struct VolumeIntegral {
     pub volume: f64,
@@ -98,32 +104,39 @@ impl CellIntegral for VolumeIntegral {
     }
 }
 
-/// Trait to implement new integrators for Voronoi Faces.
+/// Trait to implement new integrators for Voronoi faces.
 ///
-/// Integrators are expected to compute quanties of interest for Voronoi faces iteratively.
-/// The Voronoi cell is decomposed into a number of oriented tetrahedra.
-/// Tetrahedra contributing to the same face are fed one by one to the face-integrators.
+/// Integrators are expected to compute quantities of interest for Voronoi faces
+/// iteratively. The Voronoi cell is decomposed into a number of oriented
+/// tetrahedra. Tetrahedra contributing to the same face are fed one by one to
+/// the face-integrators.
 ///
 /// We use the following orientation convention:
-/// - If the three vertices are ordered counterclockwise as seen from the top, the tetrahedron is assumed to be part of
-///   the Voronoi cell and should contribute positively to integrals.
-/// - If the three vertices are ordered clockwise, the tetrahedron should substract from the integrals.
-///   this is to correct for another tetrahedron that is not fully contained within the Voronoi cell.
+///
+/// - If the three vertices are ordered counterclockwise as seen from the top,
+///   the tetrahedron is assumed to be part of the Voronoi cell and should
+///   contribute positively to integrals.
+///
+/// - If the three vertices are ordered clockwise, the tetrahedron should
+///   subtract from the integrals. this is to correct for another tetrahedron
+///   that is not fully contained within the Voronoi cell.
 pub trait FaceIntegral: Clone {
-    /// Initialize a FaceIntegral for the given ConvexCell and clipping_plane_index.
+    /// Initialize a [`FaceIntegral`] for the given [`ConvexCell`] and
+    /// clipping_plane_index.
     fn init(cell: &ConvexCell, clipping_plane_idx: usize) -> Self;
 
-    /// Update the state of the integrator using one oriented tetrahedron (with the cell's generator `gen` as top),
-    /// which is part of a cell.
+    /// Update the state of the integrator using one oriented tetrahedron (with
+    /// the cell's generator `gen` as top), which is part of a cell.
     fn collect(&mut self, v0: DVec3, v1: DVec3, v2: DVec3, gen: DVec3);
 
     /// Finalize the calculation and return the result
     fn finalize(self) -> Self;
 }
 
-/// Trait to implement new integrators that use external data in their calculation.
+/// Trait to implement new integrators that use external data in their
+/// calculation.
 pub trait FaceIntegralWithData<D: Copy>: FaceIntegral {
-    /// Initialize a CellIntegral with some extra data.
+    /// Initialize a [`CellIntegral`] with some extra data.
     fn init_with_data(cell: &ConvexCell, clipping_plane_idx: usize, data: D) -> Self;
 }
 
@@ -170,14 +183,17 @@ impl FaceIntegral for AreaCentroidIntegrator {
     }
 }
 
-/// Example implementation of a simple face integrator for computing the area of the faces of a ConvexCell
+/// Example implementation of a simple face integrator for computing the area of
+/// the faces of a [`ConvexCell`].
 pub struct AreaIntegral {
     pub area: f64,
 }
 
 impl CellIntegral for AreaIntegral {
     fn init(_cell: &ConvexCell) -> Self {
-        Self { area: 0. }
+        Self {
+            area: 0.,
+        }
     }
 
     fn collect(&mut self, v0: DVec3, v1: DVec3, v2: DVec3, gen: DVec3) {

--- a/src/voronoi/integrals.rs
+++ b/src/voronoi/integrals.rs
@@ -191,9 +191,7 @@ pub struct AreaIntegral {
 
 impl CellIntegral for AreaIntegral {
     fn init(_cell: &ConvexCell) -> Self {
-        Self {
-            area: 0.,
-        }
+        Self { area: 0. }
     }
 
     fn collect(&mut self, v0: DVec3, v1: DVec3, v2: DVec3, gen: DVec3) {

--- a/src/voronoi/voronoi_cell.rs
+++ b/src/voronoi/voronoi_cell.rs
@@ -95,11 +95,7 @@ impl VoronoiCell {
             }
         }
         // Filter out uninitialized faces and finalize the rest
-        for maybe_face in maybe_faces {
-            if let Some(face) = maybe_face {
-                faces.push(face.build());
-            }
-        }
+        faces.extend(maybe_faces.into_iter().flatten().map(|face| face.build()));
 
         let VolumeCentroidIntegrator {
             volume,

--- a/src/voronoi/voronoi_cell.rs
+++ b/src/voronoi/voronoi_cell.rs
@@ -57,21 +57,20 @@ impl VoronoiCell {
         let maybe_init_face = |maybe_face: &mut Option<VoronoiFaceBuilder<'a>>,
                                half_space: &'a HalfSpace| {
             // Only construct faces for clipping planes of valid dimensionality.
-            let should_construct_face = convex_cell
-                .dimensionality
-                .vector_is_valid(half_space.normal())
-                && match half_space {
-                    // Don't construct internal (non-boundary) faces twice.
-                    HalfSpace {
-                        right_idx: Some(right_idx),
-                        shift: None,
-                        ..
-                    } => {
-                        // Only construct face if: neighbour has not been treated yet or is inactive
-                        *right_idx > idx || mask.map_or(false, |mask| !mask[*right_idx])
-                    }
-                    _ => true,
-                };
+            let should_construct_face =
+                convex_cell.dimensionality.vector_is_valid(half_space.normal())
+                    && match half_space {
+                        // Don't construct internal (non-boundary) faces twice.
+                        HalfSpace {
+                            right_idx: Some(right_idx),
+                            shift: None,
+                            ..
+                        } => {
+                            // Only construct face if: neighbour has not been treated yet or is inactive
+                            *right_idx > idx || mask.map_or(false, |mask| !mask[*right_idx])
+                        }
+                        _ => true,
+                    };
             if should_construct_face {
                 maybe_face.get_or_insert(VoronoiFaceBuilder::new(idx, loc, half_space));
             }
@@ -99,18 +98,9 @@ impl VoronoiCell {
         // Filter out uninitialized faces and finalize the rest
         faces.extend(maybe_faces.into_iter().flatten().map(|face| face.build()));
 
-        let VolumeCentroidIntegrator {
-            volume,
-            centroid,
-        } = volume_centroid_integral.finalize();
+        let VolumeCentroidIntegrator { volume, centroid } = volume_centroid_integral.finalize();
 
-        VoronoiCell::init(
-            loc,
-            centroid,
-            volume,
-            convex_cell.safety_radius,
-            convex_cell.idx,
-        )
+        VoronoiCell::init(loc, centroid, volume, convex_cell.safety_radius, convex_cell.idx)
     }
 
     pub(super) fn finalize(&mut self, face_connections_offset: usize, face_count: usize) {
@@ -159,8 +149,7 @@ impl VoronoiCell {
                 return None;
             }
             Some(if face.left() == self.idx {
-                face.right()
-                    .expect("Face is guaranteed to not be a boundary face by now")
+                face.right().expect("Face is guaranteed to not be a boundary face by now")
             } else {
                 face.left()
             })

--- a/src/voronoi/voronoi_cell.rs
+++ b/src/voronoi/voronoi_cell.rs
@@ -34,9 +34,11 @@ impl VoronoiCell {
         }
     }
 
-    /// Build a Voronoi cell from a ConvexCell by computing the relevant integrals.
+    /// Build a [`VoronoiCell`] from a [`ConvexCell`] by computing the relevant
+    /// integrals.
     ///
-    /// Any Voronoi faces that are created by the construction of this cell are stored in the `faces` vector.
+    /// Any Voronoi faces that are created by the construction of this cell are
+    /// stored in the `faces` vector.
     pub(super) fn from_convex_cell<'a>(
         convex_cell: &'a ConvexCell,
         faces: &mut Vec<VoronoiFace>,
@@ -47,9 +49,7 @@ impl VoronoiCell {
         let mut volume_centroid_integral = VolumeCentroidIntegrator::init();
 
         let mut maybe_faces: Vec<Option<VoronoiFaceBuilder<'a>>> =
-            (0..convex_cell.clipping_planes.len())
-                .map(|_| None)
-                .collect();
+            (0..convex_cell.clipping_planes.len()).map(|_| None).collect();
 
         // Helper function to decide which faces should be constucted.
         let maybe_init_face = |maybe_face: &mut Option<VoronoiFaceBuilder<'a>>,
@@ -75,7 +75,8 @@ impl VoronoiCell {
             }
         };
 
-        // Loop over the decomposition of this convex cell into tetrahedra to compute the necessary integrals/barycenter calculations
+        // Loop over the decomposition of this convex cell into tetrahedra to compute
+        // the necessary integrals/barycenter calculations
         for tet in convex_cell.decompose() {
             // Update the volume and centroid of the cell
             volume_centroid_integral.collect(
@@ -100,7 +101,10 @@ impl VoronoiCell {
             }
         }
 
-        let VolumeCentroidIntegrator { volume, centroid } = volume_centroid_integral.finalize();
+        let VolumeCentroidIntegrator {
+            volume,
+            centroid,
+        } = volume_centroid_integral.finalize();
 
         VoronoiCell::init(loc, centroid, volume, convex_cell.safety_radius)
     }
@@ -130,25 +134,27 @@ impl VoronoiCell {
         self.safety_radius
     }
 
-    /// Get the indices of the faces that have this cell as its left or right neighbour.
+    /// Get the indices of the faces that have this cell as its left or right
+    /// neighbour.
     pub fn face_indices<'a>(&'a self, voronoi: &'a Voronoi) -> &[usize] {
         &voronoi.cell_face_connections
             [self.face_connections_offset..(self.face_connections_offset + self.face_count)]
     }
 
-    /// Get an `Iterator` over the Voronoi faces that have this cell as their left _or_ right generator.
+    /// Get an `Iterator` over the Voronoi faces that have this cell as their
+    /// left _or_ right generator.
     pub fn faces<'a>(&'a self, voronoi: &'a Voronoi) -> impl Iterator<Item = &VoronoiFace> + 'a {
-        self.face_indices(voronoi)
-            .iter()
-            .map(|&i| &voronoi.faces[i])
+        self.face_indices(voronoi).iter().map(|&i| &voronoi.faces[i])
     }
 
-    /// Get the offset of the slice of the indices of this cell's faces in the `Voronoi::cell_face_connections` array.
+    /// Get the offset of the slice of the indices of this cell's faces in the
+    /// `Voronoi::cell_face_connections` array.
     pub fn face_connections_offset(&self) -> usize {
         self.face_connections_offset
     }
 
-    /// Get the length of the slice of the indices of this cell's faces in the `Voronoi::cell_face_connections` array.
+    /// Get the length of the slice of the indices of this cell's faces in the
+    /// `Voronoi::cell_face_connections` array.
     pub fn face_count(&self) -> usize {
         self.face_count
     }

--- a/src/voronoi/voronoi_face.rs
+++ b/src/voronoi/voronoi_face.rs
@@ -27,10 +27,7 @@ impl<'a> VoronoiFaceBuilder<'a> {
     }
 
     pub fn build(self) -> VoronoiFace {
-        let AreaCentroidIntegrator {
-            area,
-            centroid,
-        } = self.area_centroid.finalize();
+        let AreaCentroidIntegrator { area, centroid } = self.area_centroid.finalize();
         VoronoiFace::new(
             self.left_idx,
             self.half_space.right_idx,

--- a/src/voronoi/voronoi_face.rs
+++ b/src/voronoi/voronoi_face.rs
@@ -27,7 +27,10 @@ impl<'a> VoronoiFaceBuilder<'a> {
     }
 
     pub fn build(self) -> VoronoiFace {
-        let AreaCentroidIntegrator { area, centroid } = self.area_centroid.finalize();
+        let AreaCentroidIntegrator {
+            area,
+            centroid,
+        } = self.area_centroid.finalize();
         VoronoiFace::new(
             self.left_idx,
             self.half_space.right_idx,
@@ -44,13 +47,16 @@ impl<'a> VoronoiFaceBuilder<'a> {
 pub struct VoronoiFace {
     /// Index of generator on the left of this face
     left: usize,
-    /// Index of the generator on the right of this face. May be `None` for boundary faces when reflective boundary conditions are used.
+    /// Index of the generator on the right of this face. May be `None` for
+    /// boundary faces when reflective boundary conditions are used.
     right: Option<usize>,
     area: f64,
     centroid: DVec3,
-    /// We follow the convention that the normals of faces point from the left generator to the right generator.
+    /// We follow the convention that the normals of faces point from the left
+    /// generator to the right generator.
     normal: DVec3,
-    /// Shift to apply to the right generator to bring it in the reference frame of the left (if any), when periodic boundary conditions are used.
+    /// Shift to apply to the right generator to bring it in the reference frame
+    /// of the left (if any), when periodic boundary conditions are used.
     shift: Option<DVec3>,
 }
 
@@ -79,7 +85,8 @@ impl VoronoiFace {
     }
 
     /// Get the index of the generator on the _right_ of this face.
-    /// Returns `None` if if this is a boundary face (i.e. obtained by clipping a Voronoi cell with the _simulation volume_).
+    /// Returns `None` if if this is a boundary face (i.e. obtained by clipping
+    /// a Voronoi cell with the _simulation volume_).
     pub fn right(&self) -> Option<usize> {
         self.right
     }
@@ -94,13 +101,15 @@ impl VoronoiFace {
         self.centroid
     }
 
-    /// Get a normal vector to this face, pointing away from the _left_ generator.
+    /// Get a normal vector to this face, pointing away from the _left_
+    /// generator.
     pub fn normal(&self) -> DVec3 {
         self.normal
     }
 
-    /// Get the shift vector (if any) to apply to the generator to the right of this face to bring it to the reference frame of this face.
-    /// Can only be `Some` for periodic Voronoi tesselations.
+    /// Get the shift vector (if any) to apply to the generator to the right of
+    /// this face to bring it to the reference frame of this face.
+    /// Can only be `Some` for periodic Voronoi tessellations.
     pub fn shift(&self) -> Option<DVec3> {
         self.shift
     }


### PR DESCRIPTION
* Added support for different arb. precision int. arithmetic backends.
  * `dashu` support (`rug` alternative, builds much faster, is 100% Rust, about the same speed as `rug` when running tests).
  * `malachite` support (`rug` alternative, builds much faster, is 100% Rust, about 6% slower than `rug` when running tests).
  * Put `rug` behind a feature flag mutually exclusive with `malachite` and `dashu`, each.
* Performance.
   * Swapped `std`'s `HashSet` for the faster `ahash` crate's version.
* Docs.
  * `cargo-spellcheck`ed everything.
  * Fixed/added intra-doc links.
  * Added feature flag docs (via `document-features` crate).
  * Shared/synced `lib.rs` docs with `README.md` via `cargo-rdme`.
* Hygene.
  * Made `clippy` (mostly) happy.
  * Ran `rustfmt`.
  * Removed `get_` prefixes from some getters (see [Rust API naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter)).
  * Made `Dimensionality` public (API UX).
